### PR TITLE
Don't override text-align attribute in tables

### DIFF
--- a/assets/sass/_base.sass
+++ b/assets/sass/_base.sass
@@ -110,9 +110,6 @@ table
   &:not(.ln-table) t
     background: var(--table-bg)
   
-th
-  text-align: left
-
 td, th
   padding: 0.5rem 1rem
   border: 1px solid var(--table-border)
@@ -120,7 +117,6 @@ td, th
 td,
 th
   padding: 0.5rem 1rem
-  text-align: left
   font-weight: 400
   &:not(:first-child)
     padding-left: 1.5rem


### PR DESCRIPTION
Removing these overrides enables support for alignment in markdown tables:

```
| Default Header | Left Align | Right Align | Center Align |
| -------------- | :--------- | ----------: | :----------: |
| *              | *          | *           | *            |
```

Without this PR:

![before](https://user-images.githubusercontent.com/17158/91248455-8f1d3780-e709-11ea-9ab5-3366eb96df03.png)

With this PR:

![after](https://user-images.githubusercontent.com/17158/91248489-a2300780-e709-11ea-93fa-128239cce544.png)
