### PR TITLE
Provide git-trackable overrides

### DIFF
--- a/assets/sass/main.sass
+++ b/assets/sass/main.sass
@@ -1,4 +1,5 @@
 @import 'variables'
+@import '../../assets/sass/variables'
 @import 'fonts'
 @import 'base'
 @import 'components'

--- a/assets/sass/main.sass
+++ b/assets/sass/main.sass
@@ -6,3 +6,4 @@
 @import 'mobile'
 @import 'syntax'
 @import 'custom'
+@import '../../assets/sass/custom'

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -18,15 +18,15 @@
     {{- $code := resources.Get $codeScriptPath | resources.ExecuteAsTemplate $codeScriptPath . }}
 
     {{- $customScriptPath := "js/custom.js" }}
+    {{ if (fileExists "../../assets/js/custom.js") }}
+      {{ $customScriptPath := "../../assets/js/custom.js" }}
+    {{ end }}
     {{- $custom := resources.Get $customScriptPath | resources.ExecuteAsTemplate $customScriptPath . }}
 
     {{- $mainScriptPath := "js/index.js" }}
     {{- $main := resources.Get $mainScriptPath | resources.ExecuteAsTemplate $mainScriptPath . }}
 
-    {{- $customSiteScriptPath := "../../assets/js/custom.js" }}
-    {{- $customSite := resources.Get $customSiteScriptPath | resources.ExecuteAsTemplate $customSiteScriptPath . }}
-
-    {{- $bundle := slice $highlight $functions $code $main $custom $customSite | resources.Concat "js/bundle.js" | resources.Fingerprint "sha512" -}}
+    {{- $bundle := slice $highlight $functions $code $main $custom | resources.Concat "js/bundle.js" | resources.Fingerprint "sha512" -}}
 
     <!-- preload assets declaration -->
     <link rel="preload" href="{{ $styles.Permalink }}" integrity = "{{ $styles.Data.Integrity }}" as="style" crossorigin="anonymous">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -23,7 +23,10 @@
     {{- $mainScriptPath := "js/index.js" }}
     {{- $main := resources.Get $mainScriptPath | resources.ExecuteAsTemplate $mainScriptPath . }}
 
-    {{- $bundle := slice $highlight $functions $code $main $custom | resources.Concat "js/bundle.js" | resources.Fingerprint "sha512" -}}
+    {{- $customSiteScriptPath := "../../assets/js/custom.js" }}
+    {{- $customSite := resources.Get $customSiteScriptPath | resources.ExecuteAsTemplate $customSiteScriptPath . }}
+
+    {{- $bundle := slice $highlight $functions $code $main $custom $customSite | resources.Concat "js/bundle.js" | resources.Fingerprint "sha512" -}}
 
     <!-- preload assets declaration -->
     <link rel="preload" href="{{ $styles.Permalink }}" integrity = "{{ $styles.Data.Integrity }}" as="style" crossorigin="anonymous">


### PR DESCRIPTION
Fixes #28, and followup to #7.

### Changes
* Checks for `_variables.s[a|c]ss` file in `<projectroot>/assets/sass/` and overrides the default `_variables.sass` file in the theme. It loads this in the same place, thus the new variables cascade down into the other Sass partials. No additional CSS files are rendered.
* Checks for `_custom.s[a|c]ss` file in `<projectroot>/assets/sass/` and adds to the theme. Concatenated as before, so no additional CSS files are rendered.
* Checks for `custom.js` file in `<projectroot>/assets/js/` and concatenates into the JS. Concatenated as before, so no additional JS files are rendered.

### Caveats
* Currently in order for the custom variables file to be parsed properly, you have to fully duplicate the `_variables.sass` file from the theme -- i.e. you can't just have a file with a new `$light` value, you have to copy over the whole file and then change that one line. I'm not sure why this is true; it must be something about the Sass inheritance.
* I've left the `_custom.sass` file (and the check for it) in place in the theme. If this seems no longer necessary (I would say so) it could be removed, but I wanted to minimize disruption.
* I've also left the `custom.js` file in the theme; same as above.
* Currently it relies on the user to create the `assets`, `assets/sass` and `assets/js` directories if they want them. An alternative would be to create these directories, with stub files, in the `exampleSite` directory so they're already there. Again, wanted to disrupt as little as possible.
* Relevant documentation in `README.md` should be updated depending on the decisions above.