### PR TITLE
Fix parentURL

### DIFF
--- a/assets/js/functions.js
+++ b/assets/js/functions.js
@@ -2,7 +2,7 @@
 const doc = document.documentElement;
 const inline = ":inline";
 // variables read from your hugo configuration
-const parentURL = '{{ absLangURL "" }}';
+const parentURL = '{{ absURL "" }}';
 let showImagePosition = "{{ .Site.Params.figurePositionShow }}";
 
 const showImagePositionLabel = '{{ .Site.Params.figurePositionLabel }}';


### PR DESCRIPTION
Static resources' path are relative to `baseUrl` not `langUrl`.