### PR TITLE
Fix hamburger menu on mobile layout: check array index

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -234,10 +234,12 @@ function fileClosure(){
       const modifiers = [':left', ':right'];
       const altArr = alt.split('::').map(x => x.trim())
 
-      altArr[1]?.split(' ').filter(Boolean).forEach(cls =>{
-        pushClass(image, cls);
-        alt = altArr[0]
-      })
+      if (altArr.length > 1) {
+        altArr[1].split(' ').filter(Boolean).forEach(cls =>{
+          pushClass(image, cls);
+          alt = altArr[0]
+        })
+      }
 
       modifiers.forEach(function(modifier){
         const canModify = alt.includes(modifier);


### PR DESCRIPTION
When tapping the hamburger menu icon on mobile layout, nothing happens. It turns out there's a syntax error with:
```
altArr[1]?.split(' ')
```

This fixes the `?` and also checks for array index