### PR TITLE
Add terms layout

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,0 +1,17 @@
+{{ define "main" }}
+{{ $pages := .Pages }}
+<div class="grid-inverse wrap content">
+  <div>
+    <h1>{{ default .Title (i18n (lower .Title)) }}</h1>
+    <div>
+      {{ range .Data.Terms.ByCount }}
+      <a href="{{ .Page.Permalink }}" class="post_tag button button_translucent">
+        {{ .Page.Title }}
+        <span class="button_tally">{{ .Count }}</span>
+      </a>
+      {{ end }}
+    </div>
+  </div>
+  {{- partial "sidebar" . }}
+</div>
+{{ end }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -31,7 +31,9 @@
     {{- range $key, $value := .Site.Taxonomies }}
     {{- if gt $value 0 }}
     <div>
-      <h2 class="mt-4 taxonomy" id="{{ $key }}-section">{{ i18n $key }}</h2>
+      <h2 class="mt-4 taxonomy" id="{{ $key }}-section">
+        <a href="{{ absLangURL $key }}">{{ i18n $key }}</a>
+      </h2>
       <nav class="tags_nav">
         {{- $onPageTags := $.Page.Params.tags }}
         {{- $slicedTags := ($value.ByCount | first $tagsLimit) }}


### PR DESCRIPTION
Use `terms.html` layout instead of `list.html` to display taxonomy terms.

Preview:
http://localhost:1313/categories/
http://localhost:1313/tags/
http://localhost:1313/series/