### PR TITLE
Disable nav_active on parent menu items (submenu)

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -14,7 +14,7 @@
     {{- $name = .Name }}
     {{- $url = absLangURL .URL }}
   {{- end }}
-  <div class="nav_parent{{ if eq $url $link }} nav_active{{ end}}">
+  <div class="nav_parent{{ if (and (not .Children) (eq $url $link)) }} nav_active{{ end}}">
     <a href="{{ $url }}" class="nav_item">{{ $name }} {{ with $children }}<img src='{{ absURL "icons/caret-icon.svg" }}' alt="icon" class="nav_icon">{{ end }}</a>
     {{- with $children }}
     <div class="nav_sub">


### PR DESCRIPTION
On the homepage submenu parent items will have the nav_active style applied which is inaccurate.

I am not not that familiar with Hugo so if there are better solutions please let me know. 

Before:
![image](https://user-images.githubusercontent.com/4967528/98605505-90dfab80-22b3-11eb-9a31-c06cda4d4847.png)
