### PR TITLE
FIX verbatim (orgmode) inline code elements handling

### DIFF
--- a/assets/js/functions.js
+++ b/assets/js/functions.js
@@ -43,6 +43,8 @@ function hasClasses(el) {
   const codeBlocks = elems('code');
   if(codeBlocks) {
     codeBlocks.forEach(function(codeBlock){
+          // Fix for orgmode inline code, leave 'verbatim' alone as well
+          containsClass(codeBlock, 'verbatim') ? pushClass(codeBlock, 'noClass') :false;
       hasClasses(codeBlock) ? false: pushClass(codeBlock, 'noClass');
     });
   }


### PR DESCRIPTION
When using orgmode as input format, inline code elements will be generated with the `verbatim`
class. Do not touch these codeblocks, as if no class was specified.

Without this all other code blocks will not render and a js error will appear in the console.