### PR TITLE
Add a default value for numberOfTagsShown

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -27,7 +27,7 @@
       </li>
       {{- end }}
     </ul>
-    {{- $tagsLimit := $s.numberOfTagsShown }}
+    {{- $tagsLimit := (default 100 $s.numberOfTagsShown) }}
     {{- range $key, $value := .Site.Taxonomies }}
     {{- if gt $value 0 }}
     <div>


### PR DESCRIPTION
Without this default, the theme fails to build at first rendering (without configuration).