### PR TITLE
Copyright section in the page footer supports year range

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -110,3 +110,6 @@ languageMenuName = "🌐"
 # Date format. Checkout https://gohugo.io/functions/format/#hugo-date-and-time-templating-reference for details.
 # dateFormat = "2006-01-02" # Default to "Jan 2, 2006".
 # customFonts = false # toggle to true if you want to use custom fonts only.
+
+# The year when ths website was created
+# since = 2016

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,8 +4,7 @@
 <footer class="footer">
   <div class="footer_inner wrap pale">
     <img src='{{ absURL "icons/apple-touch-icon.png" }}' class="icon icon_2 transparent">
-    <p>{{ i18n "copyright" }} &copy;&nbsp;
-      {{- if .Site.Params.since }}{{ .Site.Params.since }}&nbsp;-&nbsp;{{- end }}<span class="year">{{ now.Format "2006"}}</span>&nbsp;{{ upper .Site.Title }}. {{ i18n "all_rights" }}</p>
+    <p>{{ i18n "copyright" }} &copy;&nbsp;{{- if .Site.Params.since }}{{ .Site.Params.since }}&nbsp;-&nbsp;{{- end }}<span class="year">{{ now.Format "2006"}}</span>&nbsp;{{ upper .Site.Title }}. {{ i18n "all_rights" }}</p>
     {{- partial "top" .}}
   </div>
 </footer>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,7 +4,8 @@
 <footer class="footer">
   <div class="footer_inner wrap pale">
     <img src='{{ absURL "icons/apple-touch-icon.png" }}' class="icon icon_2 transparent">
-    <p>{{ i18n "copyright" }} &copy;&nbsp;<span class="year">{{ now.Format "2006"}}</span>&nbsp;{{ upper .Site.Title }}. {{ i18n "all_rights" }}</p>
+    <p>{{ i18n "copyright" }} &copy;&nbsp;
+      {{- if .Site.Params.since }}{{ .Site.Params.since }}&nbsp;-&nbsp;{{- end }}<span class="year">{{ now.Format "2006"}}</span>&nbsp;{{ upper .Site.Title }}. {{ i18n "all_rights" }}</p>
     {{- partial "top" .}}
   </div>
 </footer>


### PR DESCRIPTION
The user may have a requirement to show the copyright wording as follows, There is not only the current year, but also the year when the website was created.

> Copyright © 2016 - 2020 XXX.com. All Rights Reserved

This pull request introduce a "since" parameter

