### PR TITLE
Fixed translating "all_" key

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -43,7 +43,7 @@
         {{ end }}
         {{ if gt (len $value.ByCount) $tagsLimit }}
         <br>
-        <div class="post_tags_toggle button">{{ T (printf "all_%s" (lower (T $key))) }}</div>
+        <div class="post_tags_toggle button">{{ T (printf "all_%s" (lower $key)) }}</div>
         {{- $tagsInfo := newScratch }}
         <div class="post_tags">
           <div class="tags_list">


### PR DESCRIPTION
When generating "all_tags" key the $key variable should not be translated as it will generate the wrong "all_" key for the translation.

To replicate translate:
[tags]
other = "Etichete"

[all_tags]
other = "Toate ethichetele"

Expected behavior is to translate: "all_tags" as "Toate etichetele"
Actual result: the key to be translated is "all_etichete" and the translation doesn't happen.