### PR TITLE
footer: add year separator in copyright

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ These options set global values that some pages or all pages in the site use by 
 | dateFormat | string | no |
 | enableMathNotation | boolean | yes |
 | customFonts | boolean | no |
-| since | boolean | N/A |
+| since | integer | N/A |
 | rss_summary | boolean | N/A |
 | rss_summary_read_more_link | boolean | N/A |
 | footerLogo | string | N/A |

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -65,7 +65,7 @@ function fileClosure(){
     const date = new Date();
     const year = date.getFullYear();
     const yearEl = elem('.year');
-    yearEl ? yearEl.innerHTML = ` ${year}` : false;
+    yearEl ? yearEl.innerHTML = `${year}` : false;
   })();
   
   (function makeExternalLinks(){

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -117,5 +117,6 @@ languageMenuName = "🌐"
 # dateFormat = "2006-01-02" # Default to "Jan 2, 2006".
 # customFonts = false # toggle to true if you want to use custom fonts only.
 
-# The year when ths website was created
+# The year when ths website was created, this value is used in the copyright
+# notice of the footer.
 # since = 2016

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,7 +5,7 @@
 <footer class="footer">
   <div class="footer_inner wrap pale">
     <img src='{{ absURL (default "icons/apple-touch-icon.png" $s.footerLogo) }}' class="icon icon_2 transparent">
-    <p>{{ T "copyright" }}{{ with $s.since }} {{ . }}{{ end }}<span class="year"></span> {{ upper .Site.Title }}. {{ T "all_rights" }}</p>
+    <p>{{ T "copyright" }}{{ with $s.since }} {{ . }}-{{ end }}<span class="year"></span> {{ upper .Site.Title }}. {{ T "all_rights" }}</p>
     {{- partial "top" .}}
   </div>
 </footer>


### PR DESCRIPTION
Minor fix to the copyright in the footer and related documentation.

## Changes / fixes

Add a '-' to the year separator so that if ```since``` variable is set in
config.toml the copyright notice shows up as:

Copyright 2019-2020 CLARITY. All Rights Reserved.

instead of

Copyright 2019 2020 CLARITY. All Rights Reserved.

## Checklist

_Ensure you have checked off the following before submitting your PR._

- [X] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [X] added new dependencies
- [X] updated the [docs]() ⚠️

* Verified that the copyright shows up in <since>-<current> format.
* Removed the space in the year so that its not hardcoded and can be controlled if required in the referencing content.
* Updated ```exampleSite/config.toml``` to include a comment explaining where ```since``` variable is used.
* Updated ```README.md``` to reflect ```since``` variable is an integer