### PR TITLE
Logo/nav_brand should link to root url.

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -3,7 +3,7 @@
 {{ $logo := $params.logo }}
 <header class="nav_header" >
   <nav class="nav">
-    <a href='{{ absLangURL "" }}' class="nav_brand nav_item{{ if eq $centerLogo true }} nav_hide{{ end }}">
+    <a href='{{ absLangURL "/" }}' class="nav_brand nav_item{{ if eq $centerLogo true }} nav_hide{{ end }}">
       {{- with $logo }}
       <img src="{{ absURL . }}" class="logo">
       {{- else }}


### PR DESCRIPTION
## Changes / fixes

Hi,

I undefine baseURL in my site as I prefer relative links. However, there is a bug which occurs when baseURL is undefined.

Pre-this-PR:

If baseURL is `http://example.com`, then `{{ absLangURL "" }}` produces `http://example.com` ... which is partially correct but works.

If baseURL is undefined, then `{{ absLangURL "" }}` produces an empty string (ie. '') ... which is incorrect. It just links back to the existing page instead of the root of the site.

Post-this-PR:

If baseURL is `http://example.com`, then `{{ absLangURL "/" }}` produces `http://example.com/` ... which is more correct.

If baseURL is undefined, then `{{ absLangURL "/" }}` produces `/` ... which is correct.

## Screenshots (if applicable)

Not applicable

## Checklist

_Ensure you have checked off the following before submitting your PR._

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [ ] added new dependencies - Not Applicable
- [ ] updated the [docs]() - Not Applicable
