### PR TITLE
Add page parameters: `sidebar` and `singleColumn`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ These options can be set from a page [frontmatter](https://gohugo.io/content-man
 | enableMathNotation | boolean | yes |
 | showDate | boolean | N/A |
 | showShare | boolean | N/A |
+| sidebar | boolean | N/A |
+| singleColumn | boolean | N/A |
 
 ### Modify Menus
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -7,7 +7,7 @@
 {{- end }}
 {{- $image := $scratch.Get "image" }}
 {{- $bg := (path.Join "images" $image | absLangURL) }}
-<div class="grid-inverse wrap content">
+<div class="{{ if ne .Params.singleColumn true }}grid-inverse {{ end }}wrap content">
   <article class="post_content">
     <h1 class="post_title">{{ .Title }}</h1>
     {{- partial "post-meta" . }}
@@ -25,6 +25,8 @@
     {{ end }}
     {{- partial "i18nlist" . }}
   </article>
-  {{- partial "sidebar" . }}
+  {{- if ( ne .Params.sidebar false ) }}
+    {{- partial "sidebar" . }}
+  {{ end }}
 </div>
 {{- end }}


### PR DESCRIPTION
## Changes / fixes

This PR adds two new page parameters `sidebar` and `singleColumn` to disable the sidebar and multi-column display respectively.

I have a post which is a wide table so I want to display it in single column. At the same time, I'm undecided whether I want to display the sidebar (at the bottom) in single column mode so I created a separate `sidebar` variable.

Also, to achieve single column mode, I just omitted the 'grid-inverse' class. Although this works, I'm not entirely sure it is 100% correct. Please check (as you understand the css structure better than I). If there's a better way to achieve this, please let me know and I'll be happy to reconsider re-rolling this PR.

## Screenshots (if applicable)

N/A

## Checklist

_Ensure you have checked off the following before submitting your PR._

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [ ] added new dependencies - N/A
- [x] updated the [docs]() ⚠️
