### PR TITLE
fix hugo build failed: can't evaluate field Title in type string

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,6 +1,7 @@
 {{- define "main" }}
 {{- $s := .Site.Params }}
 {{- $p := .Params }}
+{{- $t := .Title }}
 {{- $scratch := newScratch }}
 {{- if isset $p "image" }}
   {{- $scratch.Set "image" $p.image }}
@@ -11,12 +12,11 @@
 {{- $bg := absLangURL (path.Join "images" $image) }}
 <div class="{{ if ne $p.singleColumn true }}grid-inverse {{ end }}wrap content">
   <article class="post_content">
-    {{- $t := .Title }}
     <h1 class="post_title">{{ $t }}</h1>
     {{- partial "post-meta" . }}
     {{ partial "share" . }}
     {{ with $p.featureImage }}
-    <img src="{{ . }}" class="image_featured" alt="{{ .Title }}">
+    <img src="{{ . }}" class="image_featured" alt="{{ $t }}">
     {{ end }}
     {{ if $p.toc }}
     <h2>{{ T "overview" }}</h2>


### PR DESCRIPTION
hugo build failed:

```bash
execute of template failed: template: _default/single.html:19:54: executing "main" at <.Title>: can't evaluate field Title in type string
```

## Changes / fixes

- fix issue #141 