### PR TITLE
There is an extra space in line 6

### DIFF
--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -3,7 +3,7 @@
   {{- with .logo }}
   <img src="{{ absURL . }}" class="logo" alt="{{ $t }}">
   {{- else -}}
-    {{- $t  -}}
+    {{- $t -}}
   {{- end }}
   {{- if ne (strings.HasSuffix .class "center") true }}
   <div class="nav_close">


### PR DESCRIPTION
This PR...

## Changes / fixes
I beleive the extra space in this file is causing issues in Netlify from compling this theme. Used the recommended install settings (submodule).

Build time error is:
Error: "/opt/build/repo/themes/hugo-clarity/layouts/partials/logo.html:6:1": parse failed: template: partials/logo.html:6: illegal number syntax: "-"


## Screenshots (if applicable)

(prefer animated gif)

## Checklist

_Ensure you have checked off the following before submitting your PR._

- [X] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [N/A] added new dependencies
- [N/A] updated the [docs]() ⚠️
