### PR TITLE
Removing Extra Space on Icon Name.

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,7 +4,7 @@
   {{ partialCached "math" . }}
 {{- end }}
 {{- $iconsDir := default "icons/" .Site.Params.iconsDir }}
-{{- $defaultFooterLogo := printf "%s%s" $iconsDir "apple-touch-icon.png "}}
+{{- $defaultFooterLogo := printf "%s%s" $iconsDir "apple-touch-icon.png"}}
 <footer class="footer">
   <div class="footer_inner wrap pale">
     <img src='{{ absURL (default $defaultFooterLogo $s.footerLogo) }}' class="icon icon_2 transparent" alt="{{ $t }}">


### PR DESCRIPTION

This PR removes the Extra Space next to the default footer logo, the extra space causes a 404 Not Found when using the theme in a new Site.

## Changes / fixes

- Extra Space in the Default Footer Logo is removed. Fixes icon not found issue.

## Screenshots (if applicable)
<img width="625" alt="Screen Shot 2021-04-02 at 12 53 05 am" src="https://user-images.githubusercontent.com/17462982/113304521-d88fce00-934d-11eb-96c4-8fbc32a0d7e1.png">


## Checklist

_Ensure you have checked off the following before submitting your PR._

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [ ] added new dependencies
- [ ] updated the [docs]() ⚠️
