### PR TITLE
Fix post meta visibility issues

### DIFF
--- a/layouts/partials/post-meta.html
+++ b/layouts/partials/post-meta.html
@@ -1,22 +1,38 @@
-<div class="post_meta">
-  {{ if ( ne .Params.showDate false ) }}
+{{- $showShare := eq (.Param "showshare") true }}
+{{- $showDate := eq (.Param "showdate") true }}
+{{- $showReadTime := eq (.Param "showreadtime") true }}
+{{- $showPostMeta := or ($showShare) ($showDate) ($showReadTime) }}
+{{- $scratch := newScratch }}
+{{- $scratch.Set "writeSeparator" false }}
+{{- if $showPostMeta }}
+  <div class="post_meta">
+{{- end }}
+  {{- if $showDate }}
     <span>{{ partial "sprite" (dict "icon" "calendar") }}</span>
     <span class="post_date">
       {{ .Date.Format (default "Jan 2, 2006" $.Site.Params.dateFormat) -}}
     </span>
+    {{- $scratch.Set "writeSeparator" true }}
   {{- end }}
-  {{ if ne .Params.showReadTime false }}
-    <span class="post_time"> · {{ T "reading_time" . }}&nbsp;</span>
-  {{ end }}
+  {{- if $showReadTime }}
+    <span class="post_time">{{ if ($scratch.Get "writeSeparator") }} · {{ end }}{{ T "reading_time" . }}</span>
+    {{- $scratch.Set "writeSeparator" true }}
+  {{- end }}
   {{- with .Params.tags -}}
-     <span>
-       {{- range . }}
-         {{- $tag := urlize . }} · 
-         <a href='{{ absLangURL (printf "tags/%s" $tag) }}' title="{{ . }}" class="post_tag button button_translucent">
-           {{- . }}
-         </a>
-       {{- end }}
-     </span>
+    <span>
+      {{- if ($scratch.Get "writeSeparator") }} · {{ end }}
+      {{- range . }}
+        {{- $tag := urlize . -}}
+        <a href='{{ absLangURL (printf "tags/%s" $tag) }}' title="{{ . }}" class="post_tag button button_translucent">
+          {{- . }}
+        </a>
+      {{- end }}
+    </span>
+    {{- $scratch.Set "writeSeparator" true }}
   {{- end }}
-  <span class="page_only"> · {{ partial "share" . }}</span>
-</div>
+  {{- if $showShare }}
+    <span class="page_only">{{ if ($scratch.Get "writeSeparator") }}&nbsp;· {{ end }}{{ partial "share" . }}</span>
+  {{- end }}
+{{- if $showPostMeta }}
+  </div>
+{{- end }}

--- a/layouts/partials/share.html
+++ b/layouts/partials/share.html
@@ -1,18 +1,16 @@
-{{ if and ( ne .Site.Params.showShare false ) ( ne .Params.showShare false ) }}
-  {{- $s := T "share_on" }}
-  <div class="post_share">
-    {{ $s }}:
-    <a href="https://twitter.com/intent/tweet?text={{ .Title }}&url={{ .Permalink }}&tw_p=tweetbutton" class="twitter" title="{{ $s }} Twitter" target="_blank" rel="nofollow">
-      {{ partial "sprite" (dict "icon" "twitter") }}
-    </a>
-    <a href="https://www.facebook.com/sharer.php?u={{ .Permalink }}&t={{ .Title }}" class="facebook" title="{{ $s }} Facebook" target="_blank" rel="nofollow">
-      {{ partial "sprite" (dict "icon" "facebook") }}
-    </a>
-    <a href="#linkedinshare" id = "linkedinshare" class="linkedin" title="{{ $s }} LinkedIn" rel="nofollow">
-      {{ partial "sprite" (dict "icon" "linkedin") }}
-    </a>
-    <a href="{{ .Permalink }}" title="Copy Link" class="link link_yank">
-      {{ partial "sprite" (dict "icon" "copy") }}
-    </a>
-  </div>
-{{- end }}
+{{- $s := T "share_on" -}}
+<div class="post_share">
+  {{ $s }}:
+  <a href="https://twitter.com/intent/tweet?text={{ .Title }}&url={{ .Permalink }}&tw_p=tweetbutton" class="twitter" title="{{ $s }} Twitter" target="_blank" rel="nofollow">
+    {{ partial "sprite" (dict "icon" "twitter") }}
+  </a>
+  <a href="https://www.facebook.com/sharer.php?u={{ .Permalink }}&t={{ .Title }}" class="facebook" title="{{ $s }} Facebook" target="_blank" rel="nofollow">
+    {{ partial "sprite" (dict "icon" "facebook") }}
+  </a>
+  <a href="#linkedinshare" id = "linkedinshare" class="linkedin" title="{{ $s }} LinkedIn" rel="nofollow">
+    {{ partial "sprite" (dict "icon" "linkedin") }}
+  </a>
+  <a href="{{ .Permalink }}" title="Copy Link" class="link link_yank">
+    {{ partial "sprite" (dict "icon" "copy") }}
+  </a>
+</div>


### PR DESCRIPTION
## Changes / fixes

1. Removed empty DIV with lone separator dot being created when post date, read time, tags and share toolbar are all turned off by page/site variables (showReadTime, showDate, showShare)
2. Fix global site variables showReadTime, showDate, showShare not being read when same page variables were not present. Now uses .Param function instead of .Params collection to read either page variable, if present, otherwise reads global site variable
3. Fix excess trailing separating dot when some or all post meta items are turned off. Now dot is only added between two items if previous item is present.