### PR TITLE
Fixed missing post_meta div around tag cloud

### DIFF
--- a/layouts/partials/post-meta.html
+++ b/layouts/partials/post-meta.html
@@ -1,7 +1,7 @@
 {{- $showShare := eq (.Param "showshare") true }}
 {{- $showDate := eq (.Param "showdate") true }}
 {{- $showReadTime := eq (.Param "showreadtime") true }}
-{{- $showPostMeta := or ($showShare) ($showDate) ($showReadTime) }}
+{{- $showPostMeta := or ($showShare) ($showDate) ($showReadTime) (isset .Params "tags") }}
 {{- $scratch := newScratch }}
 {{- $scratch.Set "writeSeparator" false }}
 {{- if $showPostMeta }}


### PR DESCRIPTION
## Changes / fixes

Fixed missing "post_meta" div around tag cloud when post has tags but showShare, showDate and showReadTime were all set to false.