### PR TITLE
Fix post meta with default config

### DIFF
--- a/layouts/partials/post-meta.html
+++ b/layouts/partials/post-meta.html
@@ -1,6 +1,6 @@
-{{- $showShare := eq (.Param "showshare") true }}
-{{- $showDate := eq (.Param "showdate") true }}
-{{- $showReadTime := eq (.Param "showreadtime") true }}
+{{- $showShare := ne (.Param "showshare") false }}
+{{- $showDate := ne (.Param "showdate") false }}
+{{- $showReadTime := ne (.Param "showreadtime") false }}
 {{- $showPostMeta := or ($showShare) ($showDate) ($showReadTime) (isset .Params "tags") }}
 {{- $scratch := newScratch }}
 {{- $scratch.Set "writeSeparator" false }}

--- a/layouts/partials/post-meta.html
+++ b/layouts/partials/post-meta.html
@@ -1,7 +1,7 @@
 {{- $showShare := eq (.Param "showshare") true }}
 {{- $showDate := eq (.Param "showdate") true }}
 {{- $showReadTime := eq (.Param "showreadtime") true }}
-{{- $showPostMeta := or ($showShare) ($showDate) ($showReadTime) }}
+{{- $showPostMeta := or ($showShare) ($showDate) ($showReadTime) (isset .Params "tags") }}
 {{- $scratch := newScratch }}
 {{- $scratch.Set "writeSeparator" false }}
 {{- if $showPostMeta }}


### PR DESCRIPTION
## Changes / fixes

Fixed treating showShare, showDate, showReadTime as having default value FALSE when these params are not present in config or front matter. The issue was introduced by my previous commit "Fixed post meta not showing up with default config".