### PR TITLE
Fix post meta visibility issues (updated)

### DIFF
--- a/layouts/partials/post-meta.html
+++ b/layouts/partials/post-meta.html
@@ -1,22 +1,39 @@
-<div class="post_meta">
-  {{ if ( ne .Params.showDate false ) }}
+{{- $showShare := ne (.Param "showshare") false }}
+{{- $showDate := ne (.Param "showdate") false }}
+{{- $showReadTime := ne (.Param "showreadtime") false }}
+{{- $showPostMeta := or ($showShare) ($showDate) ($showReadTime) (isset .Params "tags") }}
+{{- $scratch := newScratch }}
+{{- $scratch.Set "writeSeparator" false }}
+{{- if $showPostMeta }}
+  <div class="post_meta">
+{{- end }}
+  {{- if $showDate }}
     <span>{{ partial "sprite" (dict "icon" "calendar") }}</span>
     <span class="post_date">
       {{ .Date.Format (default "Jan 2, 2006" $.Site.Params.dateFormat) -}}
     </span>
+    {{- $scratch.Set "writeSeparator" true }}
   {{- end }}
-  {{ if ne .Params.showReadTime false }}
-    <span class="post_time"> · {{ T "reading_time" . }}&nbsp;</span>
-  {{ end }}
+  {{- if $showReadTime }}
+    <span class="post_time">{{ if ($scratch.Get "writeSeparator") }} · {{ end }}{{ T "reading_time" . }}</span>
+    {{- $scratch.Set "writeSeparator" true }}
+  {{- end }}
   {{- with .Params.tags -}}
-     <span>
-       {{- range . }}
-         {{- $tag := urlize . }} · 
-         <a href='{{ absLangURL (printf "tags/%s" $tag) }}' title="{{ . }}" class="post_tag button button_translucent">
-           {{- . }}
-         </a>
-       {{- end }}
-     </span>
+    <span>
+      {{- if ($scratch.Get "writeSeparator") }}&nbsp;· {{ end }}
+      {{- range . }}
+        {{- $tag := urlize . -}}
+        <a href='{{ absLangURL (printf "tags/%s" $tag) }}' title="{{ . }}" class="post_tag button button_translucent">
+          {{- . }}
+        </a>
+      {{- end }}
+    </span>
+    {{- $scratch.Set "writeSeparator" true }}
   {{- end }}
-  <span class="page_only"> · {{ partial "share" . }}</span>
-</div>
+  {{- if $showShare }}
+    <span class="page_only">{{ if ($scratch.Get "writeSeparator") }}&nbsp;·{{ end }}{{ partial "share" . }}</span>
+    {{- $scratch.Set "writeSeparator" true }}
+  {{- end }}
+{{- if $showPostMeta }}
+  </div>
+{{- end }}

--- a/layouts/partials/share.html
+++ b/layouts/partials/share.html
@@ -1,4 +1,3 @@
-{{ if and ( ne .Site.Params.showShare false ) ( ne .Params.showShare false ) }}
   {{- $s := T "share_on" }}
   <div class="post_share">
     {{ $s }}:
@@ -15,4 +14,4 @@
       {{ partial "sprite" (dict "icon" "copy") }}
     </a>
   </div>
-{{- end }}
+  


### PR DESCRIPTION
## Changes / fixes

* Fix empty div with lone separator char being created when post date, read time, tags and share toolbar are all turned off by page/site variables (showReadTime, showDate, showShare).
* Fix global site variables showReadTime, showDate, showShare not being read when same page variables were not present. Now uses .Param function instead of .Params collection to read either page variable, if present, otherwise reads global site variable.
* Fix excess separating dot when some or all post meta items are turned off. Now dot is only added between two items if previous item is present.
* Improved separator dot spacing after "read time" meta field. Presently the separator dots are inside SPAN of each meta item class, each SPAN may have slightly different margins, making separator dot spacing to look a bit uneven.