### PR TITLE
Remove gap in clickable area for post links

### DIFF
--- a/assets/sass/_components.sass
+++ b/assets/sass/_components.sass
@@ -191,6 +191,11 @@
 .post
   &_link, &_title
     margin-bottom: 0
+  &_link
+    line-height: 1
+    > a
+      display: block
+      line-height: 1.35
   &s
     margin-top: 2rem
   &_header


### PR DESCRIPTION
This PR...

## Fixes

#199

## Screenshots (if applicable)

Screenshot before, with <a> element highlighted:
![current](https://user-images.githubusercontent.com/79733/129405046-1d401203-991d-4d0c-b569-da98f8c43689.png)

Screenshot after:
![with-change](https://user-images.githubusercontent.com/79733/129405062-f063afd4-529a-4360-926f-7c9d9196f934.png)

## Checklist

_Ensure you have checked off the following before submitting your PR._

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [x] added new dependencies
- [x] [n/a] updated the [docs]() ⚠️
