### PR TITLE
Correcting makeExternalLinks() to allow 'rel' attribute to be overridden

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -81,7 +81,7 @@ function fileClosure(){
           blank = '_blank';
           noopener = 'noopener';
           attr1 = elemAttribute(link, target);
-          attr2 = elemAttribute(link, noopener);
+          attr2 = elemAttribute(link, rel);
           
           attr1 ? false : elemAttribute(link, target, blank);
           attr2 ? false : elemAttribute(link, rel, noopener);


### PR DESCRIPTION
## Short description

`makeExternalLinks()` has a small mistake that doesn't allow the `rel` attribute in an external link to be overridden.

Specifically, I wanted to do this in the `follow.html` layout partial to enable indieweb [RelMeAuth](https://indieweb.org/How_to_set_up_web_sign-in_on_your_own_domain#How_to_setup_RelMeAuth).

If you look at the file changes, you'll probably understand it right away, without the need for the long description to follow...

## Long description with screenshots

When including an external link in a layout file, you might want to override the default attributes set by the `makeExternalLinks()` function. For instance, in `follow.html`, this is used to construct the links:

```html
  <a href="{{ $url }}">
    {{ partial "sprite" (dict "icon" $label) }}
  </a>
```

By default, that will result in a link like this:

![current-default-and-overridden](https://user-images.githubusercontent.com/79733/130305563-8a6f35c9-5ad6-4154-8ffe-50a51663972e.png)

The `rel` and `target` attributes come from the `makeExternalLinks()` function.

If you set these attributes in the layout file, it should override what `makeExternalLinks()` is doing. For instance, if you set the target with `<a href="{{ $url }}" target="foo">`, you'll get `<a href="..." target="foo">`.

But because of the mistake in `makeExternalLinks()`, you can't do that with `rel`; it will always be set to `noopener`.

With the fix, the default output is the same:

![fixed-default](https://user-images.githubusercontent.com/79733/130305649-5e6f0a5b-d90e-438a-afca-23e5a47a5a8c.png)

But if you override `rel` in a layout file, e.g. with `<a href="{{ $url }}" rel="me">`, you get the overridden value in the output as well:

![fixed-overridden](https://user-images.githubusercontent.com/79733/130305663-ec030569-d241-4cb1-993e-deb417e2e415.png)

## Checklist

_Ensure you have checked off the following before submitting your PR._

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [x] n/a added new dependencies
- [x] n/a (in my opinion) updated the [docs]() ⚠️
