### PR TITLE
Related posts in series in sidebar and under content

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,19 +77,19 @@ A technology-minded theme for Hugo based on VMware's open-source [Clarity Design
 * Syntax Highlighting
 
 * Rich code block functions including:
-  
+
   1. Copy to clipboard
-  
+
   2. Toggle line wrap (dynamic)
-  
+
   3. Toggle line numbers
-  
+
   4. Language label
-  
+
   5. Toggle block expansion/contraction (dynamic)
-     
+
      To put it all in context, here is a preview showing all functionality.
-     
+
      ![code block functions](https://github.com/chipzoller/hugo-clarity/blob/master/images/syntax-block.gif)
 
 ## Prerequisites
@@ -207,39 +207,42 @@ These options set global values that some pages or all pages in the site use by 
 | since                      | integer                     | N/A                 |
 | rss_summary                | boolean                     | N/A                 |
 | rss_summary_read_more_link | boolean                     | N/A                 |
+| showRelatedInArticle       | boolean                     | yes                 |
+| showRelatedInSidebar       | boolean                     | no                  |
 | footerLogo                 | string                      | N/A                 |
 
 ### Page Parameters
 
 These options can be set from a page [frontmatter](https://gohugo.io/content-management/front-matter#readout) or via [archetypes](https://gohugo.io/content-management/archetypes/#readout).
 
-| Parameter           | Value Type         | Overrides Global |
-|:------------------- | ------------------ | ---------------- |
-| title               | string             | N/A              |
-| date                | date               | N/A              |
-| description         | string             | N/A              |
-| draft               | boolean            | N/A              |
-| featured            | boolean            | N/A              |
-| tags                | array/string       | N/A              |
-| categories          | array/string       | N/A              |
-| toc                 | boolean            | N/A              |
-| usePageBundles      | boolean            | yes              |
-| featureImage        | file path (string) | N/A              |
-| featureImageAlt     | string             | N/A              |
-| featureImageCap     | string             | N/A              |
-| thumbnail           | file path (string) | N/A              |
-| shareImage          | file path (string) | N/A              |
-| codeMaxLines        | integer            | yes              |
-| codeLineNumbers     | boolean            | yes              |
-| figurePositionShow  | boolean            | yes              |
-| figurePositionLabel | string             | no               |
-| comments            | boolean            | yes              |
-| enableMathNotation  | boolean            | yes              |
-| showDate            | boolean            | N/A              |
-| showShare           | boolean            | N/A              |
-| showReadTime        | boolean            | N/A              |
-| sidebar             | boolean            | N/A              |
-| singleColumn        | boolean            | N/A              |
+| Parameter            | Value Type         | Overrides Global |
+|:-------------------- | ------------------ | ---------------- |
+| title                | string             | N/A              |
+| date                 | date               | N/A              |
+| description          | string             | N/A              |
+| draft                | boolean            | N/A              |
+| featured             | boolean            | N/A              |
+| tags                 | array/string       | N/A              |
+| categories           | array/string       | N/A              |
+| toc                  | boolean            | N/A              |
+| usePageBundles       | boolean            | yes              |
+| featureImage         | file path (string) | N/A              |
+| featureImageAlt      | string             | N/A              |
+| featureImageCap      | string             | N/A              |
+| thumbnail            | file path (string) | N/A              |
+| shareImage           | file path (string) | N/A              |
+| codeMaxLines         | integer            | yes              |
+| codeLineNumbers      | boolean            | yes              |
+| figurePositionShow   | boolean            | yes              |
+| figurePositionLabel  | string             | no               |
+| comments             | boolean            | yes              |
+| enableMathNotation   | boolean            | yes              |
+| showDate             | boolean            | N/A              |
+| showShare            | boolean            | N/A              |
+| showReadTime         | boolean            | N/A              |
+| sidebar              | boolean            | N/A              |
+| singleColumn         | boolean            | N/A              |
+| showRelatedInArticle | boolean            | N/A              |
 
 ### Modify Menus
 
@@ -727,3 +730,11 @@ If you prefer MathJax, create a blank `[site]/layouts/partials/math.html` and ad
 ```
 
 This file will [take precedence over](https://gohugobrasil.netlify.app/themes/customizing/) the one Clarity provides and the site will load MathJax instead of KaTeX.
+
+### Related Content
+
+Related content within a `series` taxonomy can be shown at the end of a piece of content, or optionally on the sidebar above the Related Content section.
+
+The site configuration option `showRelatedInArticle` controls if this option is enabled. The same configuration option can be used in a posts frontmatter to disable the feature (but the site configuration overrides the per-page option).
+
+Likewise, the site configuration option `showRelatedInSidebar` controls if related content is shown on the sidebar. There is no corresponding option within a post to disable this.

--- a/archetypes/post.md
+++ b/archetypes/post.md
@@ -15,6 +15,7 @@ shareImage: "/images/path/share.png" # Designate a separate image for social med
 codeMaxLines: 10 # Override global value for how many lines within a code block before auto-collapsing.
 codeLineNumbers: false # Override global value for showing of line numbers within code block.
 figurePositionShow: true # Override global value for showing the figure label.
+showRelatedInArticle: false # Override global value for showing related posts in this series at the end of the content.
 categories:
   - Technology
 tags:

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -84,8 +84,12 @@ languageMenuName = "🌐"
 # notice of the footer.
 # since = 2016
 
-# tell hugo where you store your icons e.g favicons. This is useful if you're using an apache server and there are conflicts >> see issue https://github.com/chipzoller/hugo-clarity/issues/74. If this is applicable to you, be sure to copy the contents of https://github.com/chipzoller/hugo-clarity/tree/master/static/icons to your preferred icons directory 
+# tell hugo where you store your icons e.g favicons. This is useful if you're using an apache server and there are conflicts >> see issue https://github.com/chipzoller/hugo-clarity/issues/74. If this is applicable to you, be sure to copy the contents of https://github.com/chipzoller/hugo-clarity/tree/master/static/icons to your preferred icons directory
 iconsDir = "icons/" # without a leading forward slash
+
+# Show related content at the end of an article based on the 'series' taxonomy. Can be set in post front matter.
+# showRelatedInArticle = false
+# showRelatedInSidebar = false
 
 # website author
 [author]

--- a/i18n/ca.toml
+++ b/i18n/ca.toml
@@ -51,3 +51,6 @@ other = "Resum"
 
 [reading_time]
 other = "{{ .ReadingTime }} min lectura"
+
+[series_posts]
+other = "Publicacions d'aquesta sèrie"

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -70,4 +70,5 @@ other = "Mit"
 [img_pb_desc]
 other = "Informationen zu Hugo Page Bundles"
 
-
+[series_posts]
+other = "Beiträge in dieser Serie"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -69,3 +69,6 @@ other = "Using"
 
 [img_pb_desc]
 other = "Information about Hugo Page Bundles"
+
+[series_posts]
+other = "Posts in this series"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -70,3 +70,5 @@ other = "Usando"
 [img_pb_desc]
 other = "Información sobre Hugo Page Bundles"
 
+[series_posts]
+other = "Publicaciones en esta serie"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -70,3 +70,5 @@ other = "Utiliser"
 [img_pb_desc]
 other = "Des informations sur Hugo Page Bundles"
 
+[series_posts]
+other = "Articles dans cette série"

--- a/i18n/pt.toml
+++ b/i18n/pt.toml
@@ -70,3 +70,5 @@ other = "Usando"
 [img_pb_desc]
 other = "Informação sobre Hugo Page Bundles"
 
+[series_posts]
+other = "Postagens nesta série"

--- a/i18n/tr.toml
+++ b/i18n/tr.toml
@@ -70,3 +70,5 @@ other = "Kullanma"
 [img_pb_desc]
 other = "Hakkında bilgi Hugo Page Bundles"
 
+[series_posts]
+other = "Posts in this series"

--- a/i18n/zh-CN.toml
+++ b/i18n/zh-CN.toml
@@ -70,3 +70,5 @@ other = "使用"
 [img_pb_desc]
 other = "相关信息 Hugo Page Bundles"
 
+[series_posts]
+other = "Posts in this series"

--- a/i18n/zh-TW.toml
+++ b/i18n/zh-TW.toml
@@ -70,3 +70,5 @@ other = "使用"
 [img_pb_desc]
 other = "相關信息 Hugo Page Bundles"
 
+[series_posts]
+other = "Posts in this series"

--- a/i18n/zh.toml
+++ b/i18n/zh.toml
@@ -70,3 +70,5 @@ other = "使用"
 [img_pb_desc]
 other = "相關信息 Hugo Page Bundles"
 
+[series_posts]
+other = "Posts in this series"

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -24,6 +24,17 @@
     <div class="post_body">
       {{- .Content }}
     </div>
+
+    {{- $showRelatedInArticle := true }}
+    {{- if eq $s.showRelatedInArticle false }}
+      {{- $showRelatedInArticle = false }}
+    {{- else if eq $p.showRelatedInArticle false }}
+      {{- $showRelatedInArticle = false }}
+    {{- end }}
+    {{- if ne $showRelatedInArticle false }}
+      {{- partial "related" . }}
+    {{- end }}
+
     {{- $showComments := true }}
     {{- if eq $s.comments false }}
       {{- $showComments = false }}
@@ -34,6 +45,7 @@
       {{- partial "comments" . }}
     {{- end }}
     {{- partial "i18nlist" . }}
+
   </article>
   {{- if ( ne $p.sidebar false ) }}
     {{- partial "sidebar" . }}

--- a/layouts/partials/related.html
+++ b/layouts/partials/related.html
@@ -1,0 +1,9 @@
+{{ if isset .Params "series" }}
+{{$related := where .Site.RegularPages ".Params.series" "eq" .Params.series }}
+	<h2 class="post_related">Posts in this Series</h2>
+	<ul>
+	  {{ range $related }}
+	      <li><a href="{{ .Permalink }}" class="nav-link" title="{{ .Title }}">{{ .Title }}</a></li>
+	  {{ end }}
+	</ul>
+{{ end }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -26,6 +26,23 @@
       <a href='{{ absLangURL (default "about/" $s.introURL) }}' class="button mt-1" role="button" title='{{ $r }}'>{{ $r }}</a>
       {{- end }}
     {{- end }}
+
+    {{- $relatedInSidebar := true }}
+    {{- if eq $s.showRelatedInSidebar false }}
+      {{ $relatedInSidebar = false }}
+    {{- end }}
+    {{ if (and ($relatedInSidebar) (isset .Params "series") ) }}
+      {{$related := where .Site.RegularPages ".Params.series" "eq" .Params.series }}
+	    <h2 class="mt-4">{{ T "series_posts" }}</h2>
+      <ul>
+        {{ range $related }}
+        <li>
+          <a href="{{ .Permalink }}" class="nav-link" title="{{ .Title }}">{{ .Title }}</a>
+        </li>
+        {{ end }}
+      </ul>
+    {{ end }}
+
     {{- $posts := where (where .Site.RegularPages "Permalink" "!=" .Permalink) "Type" "in" $s.mainSections }}
     {{- $featured := default 8 $s.numberOfFeaturedPosts }}
     {{- with first $featured (where $posts "Params.featured" true)}}


### PR DESCRIPTION
This PR...

## Changes / fixes

- Adds a "Posts in this series" block in the sidebar
- Adds a related posts section under the content in a post
- Based on `series` taxonomy tag.

## Screenshots (if applicable)


## Checklist

_Ensure you have checked off the following before submitting your PR._

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [x] added new dependencies
- [x] updated the [docs]() ⚠️
