### PR TITLE
Sidebar: fix introDescription replaced by "true" (on post view only)

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -3,7 +3,7 @@
   <section class="sidebar_inner">
     {{- $introDescription := $s.introDescription }}
     {{- with .Params.introDescription }}
-      {{- $introDescription = . }}
+      {{- $introDescription = $s.introDescription }}
     {{- end }}
     {{- if $introDescription }}
       {{- $author := $s.Author  }}


### PR DESCRIPTION
If sidebar is activated in a post frontmatter and if the introDescription var is defined then
The author_bio text appears correctly on the list page, but on any post page the author_bio is replaced by "true"
 
this pr fix the problem (it’s a quick fix I did not really considered if it might have side effects). I installed it on my site.
