### PR TITLE
Adding Utterances Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,6 +693,20 @@ You can override these setting from each post individually. For example, you may
 
 > please use `comments` and not `comment`
 
+#### Utterances Commenting Support
+
+ If you wish use [Utterances](https://github.com/utterance/utterances) comments on your site, you'll need to perform the following:
+
+ * Ensure you have a GitHub public repository, which you've granted permissions to the [Utterances GitHub App](https://github.com/apps/utterances). 
+ * Comment out the line for `disqusShortname = ""` in the `/config/_default/config.toml` file.
+ * Set `comments = true` in the `/config/_default/params.toml` file.
+ * Configure the utterances parameters in the `/config/_default/params.toml` file.
+
+ Utterances is loaded in the `comments.html` partial by referring to the `utterances.html` partial.   Since `single.html` layout loads comments if comments are enabled, you must ensure *both* the `comments` and `utterances` parameters are configured.
+ 
+
+
+
 ### Math notation
 
 Clarity uses [KaTeX](https://katex.org/) for math type setting if `enableMathNotation` is set to `true` in global or page parameters (the latter takes precedence).

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -70,6 +70,12 @@ languageMenuName = "🌐"
 # Enable or disable comments globally. Default to true.
 # comments = false
 
+# Enable or disable Utterances (https://github.com/utterance/utterances) Github Issue-Based Commenting
+# utterances = true  #Run the utterances script in the single.html layout to load https://utteranc.es comments
+# utterancesRepo = "GHUsername/Repository.Name" # Utterances is enabled when this param is set
+# utterancesTheme = "github-light" # Default: github-dark
+# utterancesIssueTerm = "pathname" # Default: pathname
+
 # Maximum number of recent posts.
 # numberOfRecentPosts = 8
 

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -1,4 +1,9 @@
 <div class="post_comments">
-  {{ template "_internal/disqus.html" . }}
+  {{ if .Site.DisqusShortname }}
+    {{ template "_internal/disqus.html" . }}
+  {{ end }}
+  {{ if .Site.Params.utterances }}
+    {{ template "partials/utterances.html" . }}
+  {{ end }}
   <!-- add custom comments markup here -->
 </div>

--- a/layouts/partials/utterances.html
+++ b/layouts/partials/utterances.html
@@ -1,0 +1,9 @@
+{{ if .Site.Params.utterancesRepo }}
+ <script src="https://utteranc.es/client.js"
+         repo="{{.Site.Params.utterancesRepo}}"
+         issue-term="{{.Site.Params.utterancesIssueTerm | default "pathname"}}"
+         theme="{{.Site.Params.utterancesTheme | default "github-dark"}}"
+         crossorigin="anonymous"
+         async>
+ </script>
+ {{ end }}


### PR DESCRIPTION
Adding support for Utterances Comments

Signed-off-by: Robert Terakedis <26422950+rterakedis@users.noreply.github.com>

This PR adds support for the [Utterances](https://utteranc.es) Github-based commenting system.   It's similar to the commenting scheme used on docs.microsoft.com and helps filter comments by requiring the user is logged-in via a GitHub account.

## Changes / fixes

Adds a new partial (utterances.html) and modifies the comments.html partial.   I've also added new parameters (commented out) in the params.toml file.

## Screenshots (if applicable)

![Screen Shot 2022-02-09 at 12 55 54 AM](https://user-images.githubusercontent.com/26422950/153130629-a017ac56-1307-4912-a1b2-b9fc3e497ce5.png)


## Checklist

_Ensure you have checked off the following before submitting your PR._

- [X] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [ ] added new dependencies
- [X] updated the [docs]() ⚠️
