### PR TITLE
Shortcode for openstreetmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ A technology-minded theme for Hugo based on VMware's open-source [Clarity Design
   * [Hooks](#hooks)
   * [Comments](#comments)
   * [Math notation](#math-notation)
+  * [Open Street Map](#map)
 
 ## Features
 
@@ -781,3 +782,30 @@ Related content within a `series` taxonomy can be shown at the end of a piece of
 The site configuration option `showRelatedInArticle` controls if this option is enabled. The same configuration option can be used in a posts frontmatter to disable the feature (but the site configuration overrides the per-page option).
 
 Likewise, the site configuration option `showRelatedInSidebar` controls if related content is shown on the sidebar. There is no corresponding option within a post to disable this.
+
+### Map
+
+## Creating and including a map
+
+First create a map for free on https://umap.openstreetmap.fr/en/. Then include this map by using the `openstreetmap` shortcode, e.g. `{{<openstreetmap mapName="demo-map_1" >}}`
+
+## Options
+
+The only required parameter is `mapName`. All other parameters are completely optional.
+
+Available parameter are:
+- `coordX` (default `auto`)
+- `coordY` (default `auto`)
+- `scale`  (default `auto`)
+- `scaleControl` (default `true`)
+- `miniMap` (default `false`)
+- `scrollWheelZoom` (default `true`)
+- `zoomControl` (default `true`)
+- `allowEdit` (default `false`)
+- `moreControl` (default `true`)
+- `searchControl` (default `true`)
+- `tilelayersControl` (default `null`)
+- `embedControl` (default `null`)
+- `datalayersControl` (default `true`)
+- `onLoadPanel` (default `none`)
+- `captionBar` (default `false`)

--- a/exampleSite/content/post/map.md
+++ b/exampleSite/content/post/map.md
@@ -1,6 +1,6 @@
 ---
 author: Hugo Authors
-title: Using Notices
+title: Using OpenStreetMap
 date: 2022-02-14
 description: Using Map functionality within this theme using openstreetmap
 ---

--- a/exampleSite/content/post/map.md
+++ b/exampleSite/content/post/map.md
@@ -1,0 +1,8 @@
+---
+author: Hugo Authors
+title: Using Notices
+date: 2022-02-14
+description: Using Map functionality within this theme using openstreetmap
+---
+
+{{<openstreetmap mapName="demo-map_1" scale="14" coordX="-37.7989" coordY="145.0003">}}

--- a/exampleSite/content/post/notices.md
+++ b/exampleSite/content/post/notices.md
@@ -2,7 +2,7 @@
 author: Hugo Authors
 title: Using Notices
 date: 2021-08-20
-description: Using Notices functionality withhin this theme
+description: Using Notices functionality within this theme
 ---
 
 The "Notices" shortcode enables you to call out pieces of information - sidebars, warnings, tips, etc.

--- a/layouts/shortcodes/openstreetmap.html
+++ b/layouts/shortcodes/openstreetmap.html
@@ -1,0 +1,23 @@
+{{ $mapName := .Get "mapName" }}
+
+{{ $mapWidth := .Get "mapWidth" | default "100%" }}
+{{ $mapHeight := .Get "mapHeight" | default "600px" }}
+
+{{ $scaleControl := .Get "scaleControl" | default "true"  }}
+{{ $miniMap := .Get "miniMap" | default "false" }}
+{{ $scrollWheelZoom := .Get "scrollWheelZoom" | default "true" }}
+{{ $zoomControl := .Get "zoomControl" | default "true" }}
+{{ $allowEdit := .Get "allowEdit" | default "false" }}
+{{ $moreControl := .Get "moreControl" | default "true" }}
+{{ $searchControl := .Get "searchControl" | default "true" }}
+{{ $tilelayersControl := .Get "tilelayersControl" | default "null" }}
+{{ $embedControl := .Get "embedControl" | default "null" }}
+{{ $datalayersControl := .Get "datalayersControl" | default "true" }}
+{{ $onLoadPanel := .Get "onLoadPanel" | default "none" }}
+{{ $captionBar := .Get "captionBar" | default "false" }}
+
+{{ $scale := .Get "scale" }}
+{{ $coordX := .Get "coordX" }}
+{{ $coordY := .Get "coordY" }}
+
+<iframe width="{{ $mapWidth }}" height="{{ $mapHeight }}" frameBorder="0" src="https://umap.openstreetmap.fr/en/map/{{- $mapName -}}?scaleControl={{ $scaleControl }}&miniMap={{ $miniMap }}&scrollWheelZoom={{ $scrollWheelZoom }}&zoomControl={{ $zoomControl }}&allowEdit={{ $allowEdit }}&moreControl={{ $moreControl }}&searchControl={{ $searchControl }}&tilelayersControl={{ $tilelayersControl }}&embedControl={{ $embedControl }}&datalayersControl={{ $datalayersControl }}&onLoadPanel={{ $onLoadPanel }}&captionBar={{ $captionBar }}{{ with $scale}}#{{ . }}{{ end }}/{{ $coordX }}/{{ $coordY }}"></iframe>


### PR DESCRIPTION
I wanted to add a map view on the about page and managed to do this via `openstreetmap`.  Thought it would be fun to push a PR so it benefits more people. This is my first PR for a Hugo theme.

## Changes / fixes

- Added a new shortcode for adding map using `openstreetmap`
- Updated readme
- Spelling fixed on `exampleSite/content/post/notices.md`

## Screenshots (if applicable)



## Checklist

_Ensure you have checked off the following before submitting your PR._

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [x] added new dependencies
- [x] updated the [docs]() ⚠️
