### PR TITLE
added missing fileWeb assignment in case of pagebundle

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -51,6 +51,7 @@
 
 {{- $fileWeb = absURL $file -}}
 {{ if eq $bundle true }}
+  {{- $fileWeb = (path.Join $.Page.RelPermalink $file) -}}
   {{- $fileDisk = (path.Join ($scratch.Get "contentDir") (path.Join $.Page.File.Dir $file)) }}
 {{ else }}
   {{- $fileDisk = (path.Join ($scratch.Get "staticDir") $file) }}


### PR DESCRIPTION
This PR fixes broken images for sites using page bundles. 

After updating to latest version `907d62a`, images on my pages stopped showing up. I use page bundles.

## Changes / fixes

- layouts/_default/_markup/render-image.html - Copied the `$fileWeb` assignment from the `layouts/partials/image.html`. 

## Screenshots (if applicable)

(prefer animated gif)

## Checklist

_Ensure you have checked off the following before submitting your PR._

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [ ] added new dependencies
- [ ] updated the [docs]() ⚠️
