### PR TITLE
Allow setting meta keywords from config or home page content

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ These options set global values that some pages or all pages in the site use by 
 | plausible_analytics        | boolean                     | no                  |
 | matomo_analytics           | boolean                     | no                  |
 | description                | string                      | yes                 |
+| keywords                   | array of strings            | yes                 |
 | introDescription           | string                      | yes                 |
 | introURL                   | string/false                | no                  |
 | numberOfTagsShown          | integer                     | no                  |
@@ -225,6 +226,7 @@ These options can be set from a page [frontmatter](https://gohugo.io/content-man
 | title                | string             | N/A              |
 | date                 | date               | N/A              |
 | description          | string             | N/A              |
+| keywords             | array of strings   | yes              |
 | introDescription     | string             | yes              |
 | abstract             | string             | N/A              |
 | summary              | string             | N/A              |
@@ -251,7 +253,6 @@ These options can be set from a page [frontmatter](https://gohugo.io/content-man
 | sidebar              | boolean            | N/A              |
 | singleColumn         | boolean            | N/A              |
 | showRelatedInArticle | boolean            | N/A              |
-| keywords             | array of strings   | N/A              |
 
 ### Modify Menus
 

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -6,7 +6,8 @@ twitter = "@janedoe"
 largeTwitterCard = false # set to true if you want to show a large twitter card image. The default is a small twitter card image
 introDescription = "Technologist, perpetual student, teacher, continual incremental improvement."
 # introURL = "about/" # set the url for the 'read more' button below the introDescription, or set to false to not show the button
-# description = "" # set your site's description here. will be use for home page content meta tags (seo). Alternatively set this description in your homepage content file i.e content/_index.md. Whatever is set in the latter will take precedence
+# description = "A theme based on VMware's Clarity Design System for publishing technical blogs with Hugo." # Set your site's meta tag (SEO) description here. Alternatively set this description in your home page content file e.g. content/_index.md. Whatever is set in the latter will take precedence.
+# keywords = ["design", "clarity", "hugo theme"] # Set your site's meta tag (SEO) keywords here. Alternatively set these in your home page content file e.g. content/_index.md. Whatever is set in the latter will take precedence.
 
 # showShare = false # Uncomment to not show share buttons on each post. Also available in each post's front matter.
 

--- a/exampleSite/content/_index.md
+++ b/exampleSite/content/_index.md
@@ -1,5 +1,5 @@
 +++
 author = "Hugo Authors"
 description = "A theme based on VMware's Clarity Design System for publishing technical blogs with Hugo." # Set your site's meta tag (SEO) description here. This overrides any description set in your site configuration.
-keywords = ["design", "clarity", "hugo theme"] Set your site's meta tag (SEO) keywords here. These override any keywords set in your site configuration.
+keywords = ["design", "clarity", "hugo theme"] # Set your site's meta tag (SEO) keywords here. These override any keywords set in your site configuration.
 +++

--- a/exampleSite/content/_index.md
+++ b/exampleSite/content/_index.md
@@ -1,5 +1,5 @@
 +++
 author = "Hugo Authors"
-description = "A theme based on VMware's Clarity Design System for publishing technical blogs with Hugo." # set your site's description here. will be use for home page content meta tags (seo).
-keywords = ["design", "clarity","hugo theme"]
+description = "A theme based on VMware's Clarity Design System for publishing technical blogs with Hugo." # Set your site's meta tag (SEO) description here. This overrides any description set in your site configuration.
+keywords = ["design", "clarity", "hugo theme"] Set your site's meta tag (SEO) keywords here. These override any keywords set in your site configuration.
 +++

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -55,7 +55,9 @@
 {{- with $p.keywords }}
   {{- $keywords = delimit . "," }}
 {{- end }}
-<meta name="keywords" content="{{ $keywords }}" />
+{{- with $keywords }}
+  <meta name="keywords" content="{{ $keywords }}" />
+{{- end }}
 {{- if eq .Section $s.blogDir -}}
   {{- $date := ( .Date.Format "2006-02-01") -}}
   {{- $date := (time .Date) }}

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -41,7 +41,7 @@
 {{- else }}
 <meta property="og:type" content="article">
 {{- end }}
-<meta name="description" content="{{ $summary }}">
+<meta name="description" content="{{ $summary }}" />
 <meta name="twitter:card" content="{{ if $s.largeTwitterCard }}summary_large_image{{ else }}summary{{ end }}" />
 <meta name="twitter:creator" content="{{ $s.twitter }}">
 <meta name="twitter:title" content="{{ .Title }}" />
@@ -49,10 +49,11 @@
 <meta property="og:title" content="{{ $title }}" />
 <meta property="og:description" content="{{ $summary }}" />
 <meta property="og:image" content="{{ $image }}" />
+{{- $keywords := delimit $s.keywords "," }}
 {{- with $p.keywords }}
-  {{- $keywords := delimit . "," }}
-  <meta name="keywords" content="{{ $keywords }}">
+  {{- $keywords = delimit . "," }}
 {{- end }}
+<meta name="keywords" content="{{ $keywords }}" />
 {{- if eq .Section $s.blogDir -}}
   {{- $date := ( .Date.Format "2006-02-01") -}}
   {{- $date := (time .Date) }}

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -49,8 +49,9 @@
 <meta property="og:title" content="{{ $title }}" />
 <meta property="og:description" content="{{ $summary }}" />
 <meta property="og:image" content="{{ $image }}" />
+{{- $keywords := "" }}
 {{- with $s.keywords }}
-  {{- $keywords := delimit $s.keywords "," }}
+  {{- $keywords = delimit $s.keywords "," }}
 {{- end }}
 {{- with $p.keywords }}
   {{- $keywords = delimit . "," }}

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -49,7 +49,9 @@
 <meta property="og:title" content="{{ $title }}" />
 <meta property="og:description" content="{{ $summary }}" />
 <meta property="og:image" content="{{ $image }}" />
-{{- $keywords := delimit $s.keywords "," }}
+{{- with $s.keywords }}
+  {{- $keywords := delimit $s.keywords "," }}
+{{- end }}
 {{- with $p.keywords }}
   {{- $keywords = delimit . "," }}
 {{- end }}


### PR DESCRIPTION
This PR...

## Changes / fixes

- #263 
- In `params.toml` of the example site, I added commented-out versions of the meta description and keywords set in `content/_index.md` to match other overrideable settings.
- If no keywords are set in either place, the meta tag will not be rendered, which maintains prior behavior.
- Updated docs to note `keywords` presence in both config and per-page settings.

## Screenshots (if applicable)

N/A really.

## Checklist

_Ensure you have checked off the following before submitting your PR._

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [x] added new dependencies (n/a)
- [x] updated the [docs]() ⚠️
