### PR TITLE
Add Page to argument so that the usePageBundle check works

### DIFF
--- a/layouts/partials/excerpt.html
+++ b/layouts/partials/excerpt.html
@@ -9,7 +9,7 @@
     {{- with .Params.thumbnail }}
     <div class="excerpt_footer partition">
       <div class="excerpt_thumbnail">
-        {{- partial "image" (dict "file" . "alt" $.Title "type" "thumbnail") }}
+        {{- partial "image" (dict "file" . "alt" $.Title "type" "thumbnail" "Page" $.Page ) }}
       </div>
       {{ else }}
       <div class="excerpt_footer">


### PR DESCRIPTION
This PR fixes image partial for the sites using page bundle. 

When using page bundle, I keep thumbnails in the page directory. In a archive/list view. I image file is name / path is not resolved correctly. As a result thumbnail is not shown. 


## Changes / fixes

- Updates `except.html` to pass an extra `Page` variable to image partial. 

## Screenshots (if applicable)

_Can Provide if absolutely needed_

## Checklist

_Ensure you have checked off the following before submitting your PR._

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [ ] added new dependencies
- [ ] updated the [docs]() ⚠️
