### PR TITLE
Correctly load local featured images in page bundles

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -14,16 +14,16 @@
     {{- $t := .Title }}
     <h1 class="post_title">{{ $t }}</h1>
     {{- partial "post-meta" . }}
-    {{- if .Params.featureImage -}}
+    {{- with .Params.featureImage -}}
       <div class="post_featured">
-        {{- partial "image" (dict "file" .Params.featureImage "type" "featured") }}
+        {{- partial "image" (dict "file" . "type" "featured" "Page" $.Page) }}
       </div>
     {{- end -}}
     {{ if $p.toc }}
-    <div class="post_toc">
-      <h2>{{ T "overview" }}</h2>
-      {{ .TableOfContents }}
-    </div>
+      <div class="post_toc">
+        <h2>{{ T "overview" }}</h2>
+        {{ .TableOfContents }}
+      </div>
     {{ end }}
     <div class="post_body">
       {{- .Content }}


### PR DESCRIPTION
This PR...

## Changes / fixes

- #291 

This was a dumb mistake; I should have realized it was necessary after #285.

I checked, incidentally, and the meta image (opengraph etc.) doesn't require any changes; it is loading correctly.

## Screenshots (if applicable)

It's easier to just explain:

- In `exampleSite/content/post/bundle/index.md`, change `featuredImage` from a URL to `'building.png'`.
- Without this change, the image won't load, because it looks at `<baseURL>/building.png`.
- With this change, the images loads correctly at `<baseURL>/post/bundle/building.png`.

Without this change the image is not there

## Checklist

_Ensure you have checked off the following before submitting your PR._

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [x] added new dependencies (n/a)
- [x] updated the [docs]() ⚠️ (n/a)
