### PR TITLE
Improved image handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ Examples of this can also be found in the "Markdown Syntax Guide" post in the ex
 
 #### Adding figure positions to image captions
 
-You have the option of prepending a desired string such as "Figure N" to the caption text. This affects only inline images, not featured images.
+You have the option of prepending a desired string such as "Figure N" to the caption text of images within an article's content.
 
 Two global settings control this feature:
 

--- a/README.md
+++ b/README.md
@@ -34,14 +34,16 @@ A technology-minded theme for Hugo based on VMware's open-source [Clarity Design
   * [Images](#images)
     * [Organizing page resources](#organizing-page-resources)
     * [Modern image formats](#support-for-modern-image-formats)
-    * [Figure captions](#image-figure-captions)
+    * [Image captions](#image-captions)
+    * [Adding figure positions to image captions](#adding-figure-positions-to-image-captions)
     * [Inline images](#inline-images)
     * [Floating images](#float-images-to-the-left)
     * [Round borders](#round-borders-for-images)
     * [Adding CSS classes](#add-classes-to-images)
-    * [Article thumbnail image](#article-thumbnail-image)
-    * [Article featured image](#article-featured-image)
-    * [Article share image](#share-image)
+    * [Featured image](#featured-image)
+    * [Thumbnail image](#thumbnail-image)
+    * [Share image](#share-image)
+    * [Logo alignment](#logo-alignment)
   * [Code](#code)
   * [Table of contents](#table-of-contents-1)
   * [Notices](#notices)
@@ -64,15 +66,17 @@ A technology-minded theme for Hugo based on VMware's open-source [Clarity Design
 
 * Choice of whether to use [Hugo Page Bundles](https://gohugo.io/content-management/page-bundles/)
 
-* Native Image Lazy Loading
+* Native image lazy-loading
 
 * Customizable (see config)
 
-* Dark Mode (with UI controls for user preference setting)
+* Dark mode (with UI controls for user preference setting)
 
 * Toggleable table of contents
 
-* Configurable Site Disclaimer (i.e. "my views are not my employer's")
+* Toggleable automatic figure numbering
+
+* Configurable site disclaimer (i.e. "my views are not my employer's")
 
 * Flexible image configuration, and support for modern formats like WebP
 
@@ -80,7 +84,7 @@ A technology-minded theme for Hugo based on VMware's open-source [Clarity Design
 
 * Mobile support with configurable menu alignment
 
-* Syntax Highlighting
+* Syntax highlighting
 
 * Rich code block functions including:
 
@@ -352,6 +356,8 @@ A number of CSS classes are automatically added to images based on their source 
 
 Most images in Hugo Clarity are loaded [lazy](https://developer.mozilla.org/en-US/docs/Web/Performance/Lazy_loading#images_and_iframes) and [asynchronously](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/decoding) to improve site speed. Images that are not loaded in this manner include the site's logo.
 
+Images, whether used within Markdown content or using parameters like `featureImage` or `thumbnail`, can be local or remote images. Remote images (starting with `http...`) will automatically be downloaded, stored and optimized by Hugo Clarity, so that the finished site will only serve local images.
+
 #### Organizing page resources
 
 By default, Hugo Clarity assumes that page resources -- images and other related files -- are stored in the `static` or `assets` directories. Alternatively, you can opt-in to using [Hugo page bundles](https://gohugo.io/content-management/page-bundles/) by setting the `usePageBundles` option to `true` in your site parameters. Using this method, you keep a post's assets in the same directory as the post itself.
@@ -364,17 +370,34 @@ If you are using page bundles (see above) and reference `sample.jpg` in your pos
 
 Note that this does not *create* the other versions of the image for you, it simply checks to see if they exist. You may want to automate this process in your site build; [here is one example](https://github.com/rootwork/rootwork.org/blob/main/scripts/image_optimize.sh).
 
-#### Image figure captions
+#### Image captions
 
-You have the option of adding captions to images in blog posts and automatically prepending a desired string such as "Figure N" to the caption text. This is controlled via two global settings.
+Image captions are automatically generated. If an image has title text, the caption will be created from it; if an image has no title text, the alt text will be used. To display an image with alt text but no caption, use title text of a single space (`" "`).
 
-`figurePositionLabel` is a string which will be prepended to any caption text of an article image. By default, this is set to "Figure." And `figurePositionShow` controls, globally, whether to show this label. It does not affect whether to show the image's alt or title text, only the prefix figure caption. For more granular control, `figurePositionShow` can be overridden at the article level if desired.
+Examples of captions:
 
-The number will be automatically calculated and assigned after the `figurePositionLabel` text starting from the top of the article and counting down. Featured images will be excluded from this figuration.
+- `![Jane Doe](/images/jane-doe.png)` will display the local `jane-doe.png` image with a caption of "Jane Doe".
+- `![Jane Doe](https://raw.githubusercontent.com/chipzoller/hugo-clarity/master/exampleSite/static/images/jane-doe.png "This is Jane Doe")` will display the remote image `jane-doe.png` with a caption of "This is Jane Doe".
+- `![A building](/images/building.png " ")` will display the local image `building.png` with no caption.
 
-#### Image figure captions example
+Examples of this can also be found in the "Markdown Syntax Guide" post in the example site content.
 
-In this example, `figurePositionLabel` is set to "Figure" in `config.toml` and this is the first image in a given article.
+> NOTE: Due to limitations in Markdown, single and double quotes should not be used within alt or title text.
+
+#### Adding figure positions to image captions
+
+You have the option of prepending a desired string such as "Figure N" to the caption text. This affects only inline images, not featured images.
+
+Two global settings control this feature:
+
+- `figurePositionLabel` is a string which will be prepended to any caption text of an article image; by default this is set to "Figure".
+- `figurePositionShow` controls, globally, whether to show this label. (It does not affect the visibility of image captions in general, only the prepended figure position text.) For more granular control, `figurePositionShow` can be overridden at the article level if desired.
+
+Figure numbers will be automatically inserted after the `figurePositionLabel` text, starting from the top of the article and increasing as you move down.
+
+#### Example of image with figure positions added
+
+Assume that `figurePositionLabel` is set to "Figure" in `config.toml` and this is the first image in a given article.
 
 ```markdown
 ![A schematic for using Antrea with Kubernetes](./images/image-figure.png "Antrea Kubernetes nodes prepared")
@@ -382,11 +405,9 @@ In this example, `figurePositionLabel` is set to "Figure" in `config.toml` and t
 
 ![Figure captioning example](https://github.com/chipzoller/hugo-clarity/blob/master/images/image-figure.png)
 
-> NOTE: Alt text with double quotes will produce broken HTML per limitations with Markdown. It is recommended to omit any quotations from your alt text.
-
 #### Inline images
 
-To make a blog image inline, append `:inline` to its alt text.
+To make an image inline, append `:inline` to its alt text.
 
 #### Inline images example
 
@@ -395,7 +416,6 @@ To make a blog image inline, append `:inline` to its alt text.
 ![:inline](someImageUrl)
 
 <!-- an inline image with alt text -->
-
 ![text describing the image:inline](someOtherImageUrl)
 ```
 
@@ -412,7 +432,6 @@ To align a blog image to the left, append `:left` to its alt text. Article text 
 ![:left](someImageUrl)
 
 <!-- a left-floated image with alt text -->
-
 ![text describing the image:left](someOtherImageUrl)
 ```
 
@@ -427,7 +446,6 @@ To align a blog image to the right, append `:right` to its alt text. Article tex
 ![:right](someImageUrl)
 
 <!-- a right-floated image with alt text -->
-
 ![text describing the image:right](someOtherImageUrl)
 ```
 
@@ -444,11 +462,9 @@ is just another class and it can be mixed with other classes separated by space.
 ![::round](someImageUrl)
 
 <!-- an image with alt text and round borders-->
-
 ![text describing the image::round](someOtherImageUrl)
 
 <!-- a left-floating image without alt text and with round borders-->
-
 ![:left::round](someOtherImageUrl)
 ```
 
@@ -467,23 +483,9 @@ To add a CSS class to an image, append `::<classname>` to its alt text. You can 
 ![text describing the image::img-large img-shadow](someOtherImageUrl)
 ```
 
-#### Article thumbnail image
+#### Featured image
 
-Blog articles can specify a thumbnail image which will be displayed on the left of the card on the home page. Thumbnails should be square (height:width ratio of `1:1`) and a suggested dimension of 150 x 150 pixels. They are specified using a frontmatter variable as follows:
-
-```yaml
-...
-thumbnail: "images/2020-04/capv-overview/thumbnail.jpg"
-...
-```
-
-The path is relative to the `static` directory if not using [Page Bundles](#organizing-page-resources), and relative to the post's own directory if using them.
-
-The thumbnail image will take precedence over opengraph share tags if the [shareImage](#share-image) parameter is not specified.
-
-#### Article featured image
-
-Each article can specify an image that appears at the top of the content. When sharing the blog article on social media, if a thumbnail is not specified, the featured image will be used as a fallback on opengraph share tags.
+Each article can specify an image that appears at the top of the content.
 
 ```yaml
 ...
@@ -491,7 +493,7 @@ featureImage: "images/2020-04/capv-overview/featured.jpg"
 ...
 ```
 
-The path is relative to the `static` directory if not using [Page Bundles](#organizing-page-resources), and relative to the post's own directory if using them.
+The path for the featured image is relative to the `static` directory if not using [Page Bundles](#organizing-page-resources), and relative to the post's own directory if using them.
 
 Two other frontmatter settings allow you to set alt text for the featured image and an optional caption.
 
@@ -502,9 +504,25 @@ featureImageCap: 'A caption appearing below the image.' # Caption (optional).
 ...
 ```
 
+Unless specified using `featureImageCap`, a caption will not be generated for the featured image.
+
+#### Thumbnail image
+
+Each article can specify a thumbnail image which will be displayed on the left of the article's card on the home page and in lists of articles.
+
+```yaml
+...
+thumbnail: "images/2020-04/capv-overview/thumbnail.jpg"
+...
+```
+
+Thumbnails look best when square (height:width ratio of 1:1) and at least 150x150 pixels.
+
+The path for the thumbnail image is relative to the `static` directory if not using [Page Bundles](#organizing-page-resources), and relative to the post's own directory if using them.
+
 #### Share image
 
-Sometimes, you want to explicitly set the image that will be used in the preview when you share an article on social media. You can do so in the front matter.
+Each article can specify a share image which will used when the article is shared on social media.
 
 ```yaml
 ...
@@ -512,11 +530,13 @@ shareImage: "images/theImageToBeUsedOnShare.png"
 ...
 ```
 
-The path is relative to the `static` directory if not using [Page Bundles](#organizing-page-resources), and relative to the post's own directory if using them.
+If a share image is not specified, the order of precedence that will be used to determine which image applies is `thumbnail` => `featureImage` => `fallbackOgImage`. That is, if no thumbnail is specified, the featured image will be used; if neither is specified, the fallback image will be used.
 
-Note that if a share image is not specified, the order of precedence that will be used to determine which image applies is `thumbnail` => `featureImage` => `fallbackOgImage`. When sharing a link to the home page address of the site (as opposed to a specific article), the `fallbackOgImage` will be used.
+When sharing a link to the home page of the site (as opposed to a specific article), the `fallbackOgImage` will be used.
 
-#### Align logo
+The path for the share image is relative to the `static` directory if not using [Page Bundles](#organizing-page-resources), and relative to the post's own directory if using them.
+
+#### Logo alignment
 
 You can left align or center your site's logo.
 

--- a/README.md
+++ b/README.md
@@ -344,10 +344,11 @@ A number of CSS classes are automatically added to images based on their source 
 - `image_figure` when the image appears inside a `<figure>` element
 - `image_internal` when the image is local, within the site
 - `image_external` when the image is loaded from a URL
-- `image_processed` when the image has been passed through [Hugo Pipes](https://gohugo.io/hugo-pipes/introduction/) (requires the image to be using page bundles or in the `assets` directory)
+- `image_processed` when the image has been passed through [Hugo Pipes](https://gohugo.io/hugo-pipes/introduction/) (requires the image to be using page bundles or be in the `assets` directory)
 - `image_unprocessed` when the image has not been passed through Hugo Pipes
 - `image_thumbnail` when the image is in a list of content excerpts
 - `image_featured` when the image is a banner or hero image at the top of a post
+- `image_svg` when the image is an [SVG](https://en.wikipedia.org/wiki/Scalable_Vector_Graphics) (and thus [cannot be run through Hugo Pipes](https://github.com/gohugoio/hugo/issues/3700))
 
 Most images in Hugo Clarity are loaded [lazy](https://developer.mozilla.org/en-US/docs/Web/Performance/Lazy_loading#images_and_iframes) and [asynchronously](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/decoding) to improve site speed. Images that are not loaded in this manner include the site's logo.
 

--- a/README.md
+++ b/README.md
@@ -413,9 +413,11 @@ To make an image inline, append `:inline` to its alt text.
 
 ```markdown
 <!-- an inline image without alt text -->
+
 ![:inline](someImageUrl)
 
 <!-- an inline image with alt text -->
+
 ![text describing the image:inline](someOtherImageUrl)
 ```
 
@@ -429,9 +431,11 @@ To align a blog image to the left, append `:left` to its alt text. Article text 
 
 ```markdown
 <!-- a left-floated image without alt text -->
+
 ![:left](someImageUrl)
 
 <!-- a left-floated image with alt text -->
+
 ![text describing the image:left](someOtherImageUrl)
 ```
 
@@ -443,9 +447,11 @@ To align a blog image to the right, append `:right` to its alt text. Article tex
 
 ```markdown
 <!-- a right-floated image without alt text -->
+
 ![:right](someImageUrl)
 
 <!-- a right-floated image with alt text -->
+
 ![text describing the image:right](someOtherImageUrl)
 ```
 
@@ -459,12 +465,15 @@ is just another class and it can be mixed with other classes separated by space.
 
 ```markdown
 <!-- an image without alt text and round borders-->
+
 ![::round](someImageUrl)
 
 <!-- an image with alt text and round borders-->
+
 ![text describing the image::round](someOtherImageUrl)
 
 <!-- a left-floating image without alt text and with round borders-->
+
 ![:left::round](someOtherImageUrl)
 ```
 
@@ -476,6 +485,7 @@ To add a CSS class to an image, append `::<classname>` to its alt text. You can 
 
 ```markdown
 <!-- an image without alt text -->
+
 ![::img-medium](someImageUrl)
 
 <!-- an image with alt text -->

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -26,6 +26,8 @@
       {{- $file = path.Join "images" $image -}}
       {{- $image = $image.Content | resources.FromString $file -}}
     {{- end -}}
+  {{- else -}}
+    {{- $image = "" -}}
   {{- end -}}
 {{- else -}}
   {{- $scratch.Add "classes" " image_internal" -}}

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -26,7 +26,7 @@
   {{- if eq $bundle true -}}
     {{ $image = .Page.Resources.GetMatch $file }}
     {{- if and (not $image) .Page.File -}}
-      {{ $file = path.Join .Page.File.Dir $file }}
+      {{ $file = path.Join .Page.RelPermalink $file }}
       {{ $image = resources.Get $file }}
     {{- end -}}
   {{- end -}}
@@ -36,7 +36,7 @@
   dict
     "file" $file
     "image" $image
-    "dir" $.Page.File.Dir
+    "dir" $.Page.RelPermalink
     "alt" $alt
     "cap" $cap
     "classes" ($scratch.Get "classes")

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -18,8 +18,15 @@
 {{- if strings.HasPrefix $file "http" -}}
   {{- $scratch.Add "classes" " image_external" -}}
   {{- $image = resources.GetRemote $file -}}
-  {{- $file = path.Join "images" $image -}}
-  {{- $image = $image.Content | resources.FromString $file -}}
+  {{- if eq $image.MediaType.MainType "image" -}}
+    {{- if eq $image.MediaType.SubType "svg" -}}
+      {{- $image = "" -}}
+      {{- $scratch.Add "classes" " image_svg" -}}
+    {{- else -}}
+      {{- $file = path.Join "images" $image -}}
+      {{- $image = $image.Content | resources.FromString $file -}}
+    {{- end -}}
+  {{- end -}}
 {{- else -}}
   {{- $scratch.Add "classes" " image_internal" -}}
   {{ $file = (path.Clean $file) }}

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -45,7 +45,8 @@
   dict
     "file" $file
     "image" $image
-    "dir" $.Page.RelPermalink
+    "diskPath" $.Page.File.Dir
+    "webPath" $.Page.RelPermalink
     "alt" $alt
     "cap" $cap
     "classes" ($scratch.Get "classes")

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -16,7 +16,7 @@
     {{- partial "post-meta" . }}
     {{- with .Params.featureImage -}}
       <div class="post_featured">
-        {{- partial "image" (dict "file" . "type" "featured" "Page" $.Page) }}
+        {{- partial "image" (dict "file" . "alt" $p.featureImageAlt "type" "featured" "Page" $.Page) }}
       </div>
     {{- end -}}
     {{ if $p.toc }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -16,7 +16,7 @@
     {{- partial "post-meta" . }}
     {{- with .Params.featureImage -}}
       <div class="post_featured">
-        {{- partial "image" (dict "file" . "alt" $p.featureImageAlt "cap" $p.featureImageCap "type" "featured" "Page" $.Page) }}
+        {{- partial "image" (dict "file" $p.featureImage "alt" $p.featureImageAlt "cap" $p.featureImageCap "type" "featured" "Page" $.Page) }}
       </div>
     {{- end -}}
     {{ if $p.toc }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -16,7 +16,7 @@
     {{- partial "post-meta" . }}
     {{- with .Params.featureImage -}}
       <div class="post_featured">
-        {{- partial "image" (dict "file" . "alt" $p.featureImageAlt "type" "featured" "Page" $.Page) }}
+        {{- partial "image" (dict "file" . "alt" $p.featureImageAlt "cap" $p.featureImageCap "type" "featured" "Page" $.Page) }}
       </div>
     {{- end -}}
     {{ if $p.toc }}

--- a/layouts/partials/figure.html
+++ b/layouts/partials/figure.html
@@ -18,7 +18,7 @@
 {{- $bundle := .bundle -}}
 
 {{- if eq $bundle true -}}
-  {{ $file = path.Join "/" $dir $file }}
+  {{ $file = path.Join $dir $file }}
 {{- end -}}
 
 <figure>

--- a/layouts/partials/figure.html
+++ b/layouts/partials/figure.html
@@ -56,8 +56,10 @@
     />
 
     {{/* Provide caption based on image title, if it is set. */}}
-    {{- if not (eq $cap " ") -}}
-      <figcaption>{{ $cap | safeHTML }}</figcaption>
+    {{- with $cap -}}
+      {{- if not (eq $cap " ") -}}
+        <figcaption>{{ $cap | safeHTML }}</figcaption>
+      {{- end -}}
     {{- end -}}
 
   </picture>

--- a/layouts/partials/figure.html
+++ b/layouts/partials/figure.html
@@ -63,7 +63,7 @@
     {{/* Provide caption based on image title, if it is set. */}}
     {{- with $cap -}}
       {{- if not (eq $cap " ") -}}
-        <figcaption>{{ $cap | safeHTML }}</figcaption>
+        <figcaption class="{{ replace $classes "image" "caption" }}">{{ $cap | safeHTML }}</figcaption>
       {{- end -}}
     {{- end -}}
 

--- a/layouts/partials/figure.html
+++ b/layouts/partials/figure.html
@@ -19,6 +19,11 @@
 
 {{- if eq $bundle true -}}
   {{ $file = path.Join $dir $file }}
+  {{ if in $classes "image_svg" }}
+    {{ if strings.HasPrefix .file "http" }}
+      {{ $file = .file }}
+    {{- end -}}
+  {{- end -}}
 {{- end -}}
 
 <figure>

--- a/layouts/partials/figure.html
+++ b/layouts/partials/figure.html
@@ -11,17 +11,19 @@
 
 {{- $file := .file -}}
 {{- $image := .image -}}
-{{- $dir := .dir -}}
+{{- $diskPath := .diskPath -}}
+{{- $webPath := .webPath -}}
 {{- $alt := .alt -}}
 {{- $cap := .cap -}}
 {{- $classes := .classes -}}
 {{- $bundle := .bundle -}}
 
+{{- $fileWeb := .file -}}
 {{- if eq $bundle true -}}
-  {{ $file = path.Join $dir $file }}
+  {{ $fileWeb = path.Join $webPath $file }}
   {{ if in $classes "image_svg" }}
-    {{ if strings.HasPrefix .file "http" }}
-      {{ $file = .file }}
+    {{ if strings.HasPrefix $file "http" }}
+      {{ $fileWeb = $file }}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -34,9 +36,11 @@
       {{ $name := replace $file (path.Ext $file) "" }}
       {{ $ext := slice "avif" "webp" "jxl" }}
       {{- range $ext -}}
-        {{ $path := printf "%s" . | printf "%s%s" "." | printf "%s%s" $name | printf "%s" }}
-        {{- if fileExists $path -}}
-          <source srcset="{{ $path }}" type="image/{{ . }}">
+        {{ $item := printf "%s" . | printf "%s%s" "." | printf "%s%s" $name | printf "%s" }}
+        {{ $itemDisk := path.Join $diskPath $item }}
+        {{ $itemWeb := path.Join $webPath $item }}
+        {{- if fileExists $itemDisk -}}
+          <source srcset="{{ $itemWeb }}" type="image/{{ . }}">
         {{- end -}}
       {{- end -}}
     {{- end -}}
@@ -53,7 +57,7 @@
         src="{{ .RelPermalink }}"
       {{ else }}
         class="{{ $classes }} image_unprocessed"
-        src="{{ $file }}"
+        src="{{ $fileWeb }}"
       {{ end }}
       {{ with $cap }}
         title="{{ htmlEscape $cap }}"

--- a/layouts/partials/image.html
+++ b/layouts/partials/image.html
@@ -3,7 +3,7 @@
 {{- if not $alt -}}
   {{- $alt = .Text -}}
 {{- end -}}
-{{- $cap := .Title -}}
+{{- $cap := .cap -}}
 {{- $scratch := newScratch -}}
 {{- $scratch.Set "classes" "image_figure" -}}
 

--- a/layouts/partials/image.html
+++ b/layouts/partials/image.html
@@ -41,7 +41,7 @@
   {{- end -}}
 {{- else -}}
   {{- $scratch.Add "classes" " image_internal" -}}
-  {{ $file = (path.Join "/" $file) }}
+  {{ $file = (path.Clean $file) }}
   {{- if eq $bundle true -}}
     {{ $image = .Resources.GetMatch $file }}
   {{- end -}}

--- a/layouts/partials/image.html
+++ b/layouts/partials/image.html
@@ -28,8 +28,15 @@
 {{- if strings.HasPrefix $file "http" -}}
   {{- $scratch.Add "classes" " image_external" -}}
   {{- $image = resources.GetRemote $file -}}
-  {{- $file = path.Join "images" $image -}}
-  {{- $image = $image.Content | resources.FromString $file -}}
+  {{- if eq $image.MediaType.MainType "image" -}}
+    {{- if eq $image.MediaType.SubType "svg" -}}
+      {{- $image = "" -}}
+      {{- $scratch.Add "classes" " image_svg" -}}
+    {{- else -}}
+      {{- $file = path.Join "images" $image -}}
+      {{- $image = $image.Content | resources.FromString $file -}}
+    {{- end -}}
+  {{- end -}}
 {{- else -}}
   {{- $scratch.Add "classes" " image_internal" -}}
   {{ $file = (path.Join "/" $file) }}

--- a/layouts/partials/image.html
+++ b/layouts/partials/image.html
@@ -42,7 +42,7 @@
   dict
     "file" $file
     "image" $image
-    "dir" $.Page.File.Dir
+    "dir" $.Page.RelPermalink
     "alt" $alt
     "cap" $cap
     "classes" ($scratch.Get "classes")

--- a/layouts/partials/image.html
+++ b/layouts/partials/image.html
@@ -51,7 +51,8 @@
   dict
     "file" $file
     "image" $image
-    "dir" $.Page.RelPermalink
+    "diskPath" $.Page.File.Dir
+    "webPath" $.Page.RelPermalink
     "alt" $alt
     "cap" $cap
     "classes" ($scratch.Get "classes")

--- a/layouts/partials/image.html
+++ b/layouts/partials/image.html
@@ -36,6 +36,8 @@
       {{- $file = path.Join "images" $image -}}
       {{- $image = $image.Content | resources.FromString $file -}}
     {{- end -}}
+  {{- else -}}
+    {{- $image = "" -}}
   {{- end -}}
 {{- else -}}
   {{- $scratch.Add "classes" " image_internal" -}}


### PR DESCRIPTION
## Changes / fixes

- [#291#issuecomment-1116242177](https://github.com/chipzoller/hugo-clarity/issues/291#issuecomment-1116242177)
- #296
- #288

### Summary of changes

- Images correctly use `.RelPermalink` rather than a direct link, to accommodate changed permalinks when using bundles.
- Featured image captions and alt text are correctly displayed (this was a regression; unsure when).
- SVGs will no longer cause a site build failure, they simply won't be passed through Hugo Pipes/imageConfig (as Hugo doesn't support that). I also added a new `image_svg` class because I needed something to hook off of anyway and I figured we might as well provide that to users.
- Documentation updated, including clarifying some things with how image captions work.

## Screenshots (if applicable)

N/A -- this is dealing with cases not contained in any of the default exampleSite pages (so none of them are changed) and the only visual difference is that in certain use cases things show up where they didn't before.

## Checklist

_Ensure you have checked off the following before submitting your PR._

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [x] added new dependencies (n/a)
- [x] updated the [docs]() ⚠️
