### PR TITLE
Fix image position label bug

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -226,7 +226,7 @@ function fileClosure(){
   }
 
   function populateAlt(images) {
-    let imagePosition = containsClass(images[0], featuredImageClass) ? -1 : 0;
+    let imagePosition = 0;
 
     images.forEach((image) => {
       let alt = image.alt;


### PR DESCRIPTION
Signed-off-by: weru <fromweru@gmail.com>

This PR fixes a bug where image positions were starting from `Figure 0` when the `featureImage` was set in the frontmatter 

## Changes / fixes

- The aforementioned bug

## Screenshots (if applicable)

(prefer animated gif)

## Checklist

_Ensure you have checked off the following before submitting your PR._

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [ ] added new dependencies
- [ ] updated the [docs]() ⚠️
