### PR TITLE
Issue 290 allow granular search by sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -869,9 +869,7 @@ __Search Scope__
 
 - Searching within a section will yield results from that section.
 
-    For example, if you have 2 `mainSections` 1/ vegetables 2/ fruits, searching in the fruits section will only produce results for that section.
+    For example, if you have 3 sections in your content i.e `blog`, `docs` & `examples`, searching in the `docs` section will only produce results for that section.
 - Searching outside a section will search the entire site.
 
-     For example, with the above `mainSections` setup, searching from the homepage will produce results from both sections and other pages of the site.
-
-     Future implementations may include a github-like feature i.e `search all site`. This PR will leave that to a future PR
+     For example, with the above setup, searching from the homepage will produce results from the entire site.

--- a/README.md
+++ b/README.md
@@ -864,3 +864,14 @@ enableSearch = true
     Live search works even for multilingual sites.
 
     For Chinese-like languages, it may or may not work.
+
+__Search Scope__
+
+- Searching within a section will yield results from that section.
+
+    For example, if you have 2 `mainSections` 1/ vegetables 2/ fruits, searching in the fruits section will only produce results for that section.
+- Searching outside a section will search the entire site.
+
+     For example, with the above `mainSections` setup, searching from the homepage will produce results from both sections and other pages of the site.
+
+     Future implementations may include a github-like feature i.e `search all site`. This PR will leave that to a future PR

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -50,7 +50,7 @@ function initializeSearch(index) {
         results = results.slice(0,12);
       }
       resultsFragment.appendChild(resultsTitle);
-      console.log(results);
+
       results.forEach(function(result){
         let item = createEl('a');
         item.href = `${result.link}?query=${query}`;
@@ -85,7 +85,7 @@ function initializeSearch(index) {
     showResults.appendChild(resultsFragment);
   }
 
-  function search(searchTerm, scope = 'post', passive = false) {
+  function search(searchTerm, scope = null, passive = false) {
     if(searchTerm.length) {
       let rawResults = index.search(searchTerm);
       rawResults = rawResults.map(function(result){
@@ -93,9 +93,13 @@ function initializeSearch(index) {
         const resultItem = result.item;
         resultItem.score = (parseFloat(score) * 50).toFixed(0);
         return resultItem ;
-      }).filter(resultItem => {
-        return resultItem.section == scope;
-      });
+      })
+
+      if(scope) {
+        rawResults = rawResults.filter(resultItem => {
+          return resultItem.section == scope;
+        });
+      }
 
       passive ? searchResults(rawResults, searchTerm, true) : searchResults(rawResults, searchTerm);
 
@@ -119,7 +123,8 @@ function initializeSearch(index) {
         searchField.addEventListener('search', function(){
           const searchTerm = searchField.value.trim().toLowerCase();
           if(searchTerm.length)  {
-            window.location.href = new URL(`search/?query=${searchTerm}&scope=${searchScope}`, rootURL).href;
+            const scopeParameter = searchScope ? `&scope=${searchScope}` : '';
+            window.location.href = new URL(`search/?query=${searchTerm}${ scopeParameter }`, rootURL).href;
           }
         });
       }
@@ -142,7 +147,7 @@ function initializeSearch(index) {
       // search actively after search page has loaded
       const searchField = elem(searchFieldClass);
 
-      searchScope ? search(searchTerm, searchScope, true) : false;
+      search(searchTerm, searchScope, true);
 
       if(searchField) {
         searchField.addEventListener('input', function() {

--- a/layouts/partials/search/widget.html
+++ b/layouts/partials/search/widget.html
@@ -9,7 +9,7 @@
     {{- $simple = false }}
   {{ end }}
   <div class="search">
-    <input type="search" class="search_field form_field" placeholder='{{ $placeholder }}' id="find" autocomplete="off" data-scope='{{ delimit $params.mainSections "" }}'>
+    <input type="search" class="search_field form_field" placeholder='{{ $placeholder }}' id="find" autocomplete="off" data-scope='{{ .Section }}'>
     <label for="find" class="search_label">
       {{- partial "sprite" (dict "icon" "search") }}
     </label>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -2,7 +2,7 @@
 <aside class="sidebar">
   <section class="sidebar_inner">
     <br>
-    {{ partialCached "search/widget" . }}
+    {{ partial "search/widget" . }}
     {{- $introDescription := $s.introDescription }}
     {{- with .Params.introDescription }}
       {{- $introDescription = . }}


### PR DESCRIPTION
This PR fixes issue #290 

## Changes / fixes

1. Searching within a section produce results only from that section.
      For example, if you have 2 `mainSections` 1/ vegetables 2/ fruits, searching in the fruits section will only produce results for that section.
2. Searching outside a section will search the entire site.
     For example, with the above `mainSections` setup, searching from the homepage will produce results from both sections and other pages of the site.

     Future implementations may include a github-like feature i.e `search all site`. This PR will leave that to a future PR

    <img width="634" alt="Screen Shot 2022-05-15 at 00 10 53" src="https://user-images.githubusercontent.com/16350351/168448319-35bfb9dc-d963-4c85-84d5-6abadeeb397b.png">

## Screenshots (if applicable)

(prefer animated gif)

## Checklist

_Ensure you have checked off the following before submitting your PR._

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [ ] added new dependencies
- [x] updated the [docs]() ⚠️
