### PR TITLE
Run more user-supplied text through markdownify

### DIFF
--- a/assets/sass/_syntax.sass
+++ b/assets/sass/_syntax.sass
@@ -7,7 +7,7 @@
     opacity: 1
 
 code
-  font-size: 15px
+  font-size: 85%
   font-weight: 400
   overflow-y: hidden
   display: block

--- a/exampleSite/content/post/bundle/index.md
+++ b/exampleSite/content/post/bundle/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Using Hugo page bundles'
 description: 'Page bundles are an optional way to organize content within Hugo.'
+summary: "Page bundles are an optional way to organize page resources within Hugo. You can opt-in to using page bundles in Hugo Clarity with `usePageBundles` in your site configuration --- or in a page's front matter." # For the post in lists.
 date: '2022-03-24'
 aliases:
   - hugo-page-bundles

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -12,7 +12,7 @@
 <div class="{{ if ne $p.singleColumn true }}grid-inverse {{ end }}wrap content">
   <article class="post_content">
     {{- $t := .Title }}
-    <h1 class="post_title">{{ $t }}</h1>
+    <h1 class="post_title">{{ $t | markdownify }}</h1>
     {{- partial "post-meta" . }}
     {{- with .Params.featureImage -}}
       <div class="post_featured">

--- a/layouts/partials/excerpt.html
+++ b/layouts/partials/excerpt.html
@@ -22,9 +22,9 @@
             {{ $summary = .Params.abstract }}
           {{- end }}
           {{ if not ( strings.Contains $summary "<p>" ) }}
-            <p>{{ $summary }}</p>
+            <p>{{ $summary | markdownify }}</p>
           {{ else }}
-            {{ $summary }}
+            {{ $summary | markdownify }}
           {{ end }}
           <br>
           {{- $r := T "read_more" }}

--- a/layouts/partials/excerpt.html
+++ b/layouts/partials/excerpt.html
@@ -2,7 +2,7 @@
   <div class="excerpt">
     <div class="excerpt_header">
       <h3 class="post_link">
-        <a href="{{ .Permalink }}" title="{{ .Title }}">{{ .Title  }}</a>
+        <a href="{{ .Permalink }}" title="{{ .Title }}">{{ .Title | markdownify  }}</a>
       </h3>
       {{ partial "post-meta" . }}
     </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -8,7 +8,7 @@
 <footer class="footer">
   <div class="footer_inner wrap pale">
     <img src='{{ absURL (default $defaultFooterLogo $s.footerLogo) }}' class="icon icon_2 transparent" alt="{{ $t }}">
-    <p>{{ T "copyright" }}{{ with $s.since }}&nbsp;{{ . }}-{{ end }}&nbsp;<span class="year"></span>&nbsp;{{ upper $t }}. {{ T "all_rights" }}</p>
+    <p>{{ T "copyright" | markdownify }}{{ with $s.since }}&nbsp;{{ . }}-{{ end }}&nbsp;<span class="year"></span>&nbsp;{{ upper $t }}. {{ T "all_rights" | markdownify }}</p>
     {{- partialCached "top" .}}
   </div>
 </footer>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -50,7 +50,7 @@
       <ul>
         {{ range $related }}
         <li>
-          <a href="{{ .Permalink }}" class="nav-link" title="{{ .Title }}">{{ .Title }}</a>
+          <a href="{{ .Permalink }}" class="nav-link" title="{{ .Title }}">{{ .Title | markdownify }}</a>
         </li>
         {{ end }}
       </ul>
@@ -63,7 +63,7 @@
     <ul>
       {{- range . }}
       <li>
-        <a href="{{ .Permalink }}" class="nav-link" title="{{ .Title }}">{{ .Title }}</a>
+        <a href="{{ .Permalink }}" class="nav-link" title="{{ .Title }}">{{ .Title | markdownify }}</a>
       </li>
       {{- end }}
     </ul>
@@ -73,7 +73,7 @@
       {{- $recent := default 8 $s.numberOfRecentPosts }}
       {{- range first $recent $posts }}
       <li>
-        <a href="{{ .Permalink }}" class="nav-link" title="{{ .Title }}">{{ .Title }}</a>
+        <a href="{{ .Permalink }}" class="nav-link" title="{{ .Title }}">{{ .Title | markdownify }}</a>
       </li>
       {{- end }}
     </ul>


### PR DESCRIPTION
## Background

I had an emdash in a post, and using `---` for it, which gets transformed into `—` via [Goldmark's Typographer extension](https://github.com/yuin/goldmark/#built-in-extensions) if `typographer = true` is set in `markup.toml`, wasn't working in the summary text even though it was working in the main content of the post.

I realized it was because the summary text is not run through [`markdownify`](https://gohugo.io/functions/markdownify/).

## Fix

This PR runs all text through `markdownify` when it is reasonable to do so. Apart from applying Typographer if it's enabled, having it run through `markdownify` also allows for standard Hugo formatting things, like putting content within backticks into `<code>` tags. I updated a post in the example site with a summary set in order to test this.

Aside: `markdownify` does _not_ automatically include [`emojify`](https://gohugo.io/functions/emojify/), even if `enableEmoji` is turned on in config (unfortunately this setting is not exposed as a site variable; see https://github.com/gohugoio/hugo/issues/9902), so if we wanted to support emojis in any of this text we'd have to turn it on everywhere.

## Changes

In addition to regular post content (including tables of contents), the site author's description was already being run through `markdownify`, so no changes there.

The affected text **includes**:

- titles: page titles, titles in excerpts, and titles in sidebar items
- summary text
- footer items (copyright text)

With `<code>` tags now possible in elements like a title, I changed the style for it from an fixed size (15px) to a relative one (85%), which maintains the existing size in body text.

This PR **does not include** these text items:

- the page HTML `<title>` element
- meta description text
- social media (opengraph) text

because then you might have those `<code>` tags in what is supposed to be plaintext.

## Screenshots (if applicable)

Before:

![nomarkdownify](https://user-images.githubusercontent.com/79733/168694694-b46a4f43-436c-474e-880d-9992573cdbe1.png)

After (note syntax highlight and em-dash):

![markdownify](https://user-images.githubusercontent.com/79733/168694735-8f7afb02-906a-4b7e-8b64-94a8056307c2.png)

## Checklist

_Ensure you have checked off the following before submitting your PR._

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [x] added new dependencies (n/a)
- [x] updated the [docs]() ⚠️ (I don't think this requires any doc update)
