### PR TITLE
Fix broken font reference

### DIFF
--- a/assets/sass/_fonts.sass
+++ b/assets/sass/_fonts.sass
@@ -65,5 +65,5 @@
   font-family: 'Metropolis'
   font-style: italic
   font-weight: 700
-  src: local('Metropolis Bold Italic'), local('Metropolis-BoldItalic'), url('#{$font-path}/Metropolis-BoldItalic.woff.woff2') format('woff2'), url('#{$font-path}/Metropolis-BoldItalic.woff.woff') format('woff')
+  src: local('Metropolis Bold Italic'), local('Metropolis-BoldItalic'), url('#{$font-path}/Metropolis-BoldItalic.woff2') format('woff2'), url('#{$font-path}/Metropolis-BoldItalic.woff') format('woff')
   font-display: swap

--- a/assets/sass/_fonts.sass
+++ b/assets/sass/_fonts.sass
@@ -58,7 +58,7 @@
   font-family: 'Metropolis'
   font-style: normal
   font-weight: 700
-  src: local('Metropolis Bold'), local('Metropolis-Bold'), url('#{$font-path}/Metropolis-Bold.woff') format('woff2'), url('#{$font-path}/Metropolis-Bold.woff') format('woff')
+  src: local('Metropolis Bold'), local('Metropolis-Bold'), url('#{$font-path}/Metropolis-Bold.woff2') format('woff2'), url('#{$font-path}/Metropolis-Bold.woff') format('woff')
   font-display: swap
 
 @font-face


### PR DESCRIPTION
This PR...

## Changes / fixes

Noticed these while testing #299:

- there were typos in one of the font types that resulted in broken references
- there was a different font type that referenced `woff` when it meant to reference `woff2`

## Screenshots (if applicable)

Broken fonts, with `woff` reference (before):

![brokenfonts](https://user-images.githubusercontent.com/79733/168697691-ee43d8fb-af60-4dfd-9f1e-36f1f6233854.png)

Fixed fonts (after):

![fixedfonts](https://user-images.githubusercontent.com/79733/168697903-72375e79-4f59-40e5-933d-61b464bee6e6.png)

## Checklist

_Ensure you have checked off the following before submitting your PR._

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [ ] added new dependencies
- [ ] updated the [docs]() ⚠️
