### PR TITLE
Ensure builds won't choke on 404ed remote image references

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -18,7 +18,7 @@
 {{- if strings.HasPrefix $file "http" -}}
   {{- $scratch.Add "classes" " image_external" -}}
   {{- $image = resources.GetRemote $file -}}
-  {{- with $image.MediaType }}
+  {{- with $image }}
     {{- if eq $image.MediaType.MainType "image" -}}
       {{- if eq $image.MediaType.SubType "svg" -}}
         {{- $image = "" -}}

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -18,13 +18,17 @@
 {{- if strings.HasPrefix $file "http" -}}
   {{- $scratch.Add "classes" " image_external" -}}
   {{- $image = resources.GetRemote $file -}}
-  {{- if eq $image.MediaType.MainType "image" -}}
-    {{- if eq $image.MediaType.SubType "svg" -}}
-      {{- $image = "" -}}
-      {{- $scratch.Add "classes" " image_svg" -}}
+  {{- with $image.MediaType.MainType }}
+    {{- if eq $image.MediaType.MainType "image" -}}
+      {{- if eq $image.MediaType.SubType "svg" -}}
+        {{- $image = "" -}}
+        {{- $scratch.Add "classes" " image_svg" -}}
+      {{- else -}}
+        {{- $file = path.Join "images" $image -}}
+        {{- $image = $image.Content | resources.FromString $file -}}
+      {{- end -}}
     {{- else -}}
-      {{- $file = path.Join "images" $image -}}
-      {{- $image = $image.Content | resources.FromString $file -}}
+      {{- $image = "" -}}
     {{- end -}}
   {{- else -}}
     {{- $image = "" -}}

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -30,8 +30,6 @@
     {{- else -}}
       {{- $image = "" -}}
     {{- end -}}
-  {{- else -}}
-    {{- $image = "" -}}
   {{- end -}}
 {{- else -}}
   {{- $scratch.Add "classes" " image_internal" -}}

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -18,7 +18,7 @@
 {{- if strings.HasPrefix $file "http" -}}
   {{- $scratch.Add "classes" " image_external" -}}
   {{- $image = resources.GetRemote $file -}}
-  {{- with $image.MediaType.MainType }}
+  {{- with $image.MediaType }}
     {{- if eq $image.MediaType.MainType "image" -}}
       {{- if eq $image.MediaType.SubType "svg" -}}
         {{- $image = "" -}}

--- a/layouts/partials/image.html
+++ b/layouts/partials/image.html
@@ -28,13 +28,17 @@
 {{- if strings.HasPrefix $file "http" -}}
   {{- $scratch.Add "classes" " image_external" -}}
   {{- $image = resources.GetRemote $file -}}
-  {{- if eq $image.MediaType.MainType "image" -}}
-    {{- if eq $image.MediaType.SubType "svg" -}}
-      {{- $image = "" -}}
-      {{- $scratch.Add "classes" " image_svg" -}}
+  {{- with $image.MediaType.MainType }}
+    {{- if eq $image.MediaType.MainType "image" -}}
+      {{- if eq $image.MediaType.SubType "svg" -}}
+        {{- $image = "" -}}
+        {{- $scratch.Add "classes" " image_svg" -}}
+      {{- else -}}
+        {{- $file = path.Join "images" $image -}}
+        {{- $image = $image.Content | resources.FromString $file -}}
+      {{- end -}}
     {{- else -}}
-      {{- $file = path.Join "images" $image -}}
-      {{- $image = $image.Content | resources.FromString $file -}}
+      {{- $image = "" -}}
     {{- end -}}
   {{- else -}}
     {{- $image = "" -}}

--- a/layouts/partials/image.html
+++ b/layouts/partials/image.html
@@ -28,7 +28,7 @@
 {{- if strings.HasPrefix $file "http" -}}
   {{- $scratch.Add "classes" " image_external" -}}
   {{- $image = resources.GetRemote $file -}}
-  {{- with $image.MediaType }}
+  {{- with $image }}
     {{- if eq $image.MediaType.MainType "image" -}}
       {{- if eq $image.MediaType.SubType "svg" -}}
         {{- $image = "" -}}

--- a/layouts/partials/image.html
+++ b/layouts/partials/image.html
@@ -40,8 +40,6 @@
     {{- else -}}
       {{- $image = "" -}}
     {{- end -}}
-  {{- else -}}
-    {{- $image = "" -}}
   {{- end -}}
 {{- else -}}
   {{- $scratch.Add "classes" " image_internal" -}}

--- a/layouts/partials/image.html
+++ b/layouts/partials/image.html
@@ -28,7 +28,7 @@
 {{- if strings.HasPrefix $file "http" -}}
   {{- $scratch.Add "classes" " image_external" -}}
   {{- $image = resources.GetRemote $file -}}
-  {{- with $image.MediaType.MainType }}
+  {{- with $image.MediaType }}
     {{- if eq $image.MediaType.MainType "image" -}}
       {{- if eq $image.MediaType.SubType "svg" -}}
         {{- $image = "" -}}


### PR DESCRIPTION
This PR...

## Changes / fixes

- Fixes #288
- Prevents calling of remote broken image resources from crashing a site build; the worst-case scenario is you'd just get a broken image tag.

## Screenshots (if applicable)

N/A really.

## Testing

The only context in which the code change should affect anything is when you reference an image with a full URL that leads to a 404, like `https://example.com/doesnotexist.png`.

Whereas before it would try to evaluate the result, Hugo will choke if the result is empty. So now it first checks to see if the result exists, and only if it does will it evaluate it.

If you're looking directly at the code, GitHub's diffs might be confusing. I really just wrapped what was already there using `{{- with $image }}`.

## Checklist

_Ensure you have checked off the following before submitting your PR._

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [ ] added new dependencies
- [ ] updated the [docs]() ⚠️
