### PR TITLE
fix opengraph images

### DIFF
--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -1,7 +1,16 @@
-{{- $relpath := .Page.RelPermalink -}}
 {{- $summary := truncate 160 .Summary }}
 {{- $s := .Site.Params }}
 {{- $p := .Params }}
+
+{{- $relpath := "" -}}
+{{- if or $s.usePageBundles $p.usePageBundles }}
+  {{- $relpath = .Page.RelPermalink -}}
+{{- end }}
+
+{{ if eq $p.usePageBundles false }}
+  {{- $relpath = "" }}
+{{ end }}
+
 {{- with $p.description }}
   {{- $summary = truncate 160 . }}
 {{- end }}
@@ -45,6 +54,7 @@
 <meta name="twitter:card" content="{{ if $s.largeTwitterCard }}summary_large_image{{ else }}summary{{ end }}" />
 <meta name="twitter:creator" content="{{ $s.twitter }}">
 <meta name="twitter:title" content="{{ .Title }}" />
+<meta name="twitter:image" content="{{ $image }}"/>
 <meta property="og:url" content="{{ $permalink }}" />
 <meta property="og:title" content="{{ $title }}" />
 <meta property="og:description" content="{{ $summary }}" />


### PR DESCRIPTION
Signed-off-by: weru <fromweru@gmail.com>

This PR fixes a regression that was introduced when we added page bundles support

## Changes / fixes

- Only use the full page path while using page bundles
- add a Twitter image meta tag

## Screenshots (if applicable)

(prefer animated gif)

## Checklist

_Ensure you have checked off the following before submitting your PR._

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [ ] added new dependencies
- [ ] updated the [docs]() ⚠️
