### PR TITLE
Fix search-term highlighting bugs

### DIFF
--- a/assets/js/functions.js
+++ b/assets/js/functions.js
@@ -192,7 +192,6 @@ function wrapText(text, context, wrapper = 'mark') {
   let close = `</${wrapper}>`;
   let escapedOpen = `%3C${wrapper}%3E`;
   let escapedClose = `%3C/${wrapper}%3E`;
-
   function wrap(context) {
     let c = context.innerHTML;
     let pattern = new RegExp(text, "gi");

--- a/assets/js/functions.js
+++ b/assets/js/functions.js
@@ -183,16 +183,15 @@ function parseBoolean(string) {
   }
 };
 
-function wrapText(text, context, wrapper = 'mark', cssClass = '') {
+function forEach(node, callback) {
+  Array.prototype.forEach.call(node.childNodes, callback);
+}
+
+function wrapText(text, context, wrapper = 'mark') {
   let open = `<${wrapper}>`;
   let close = `</${wrapper}>`;
   let escapedOpen = `%3C${wrapper}%3E`;
   let escapedClose = `%3C/${wrapper}%3E`;
-
-  if(cssClass) {
-    open = `<${wrapper} class="${cssClass}">`;
-    escapedOpen = `%3C${wrapper} class%3D%22${cssClass}%22%3E`;
-  }
 
   function wrap(context) {
     let c = context.innerHTML;

--- a/assets/js/functions.js
+++ b/assets/js/functions.js
@@ -183,11 +183,17 @@ function parseBoolean(string) {
   }
 };
 
-function wrapText(text, context, wrapper = 'mark') {
+function wrapText(text, context, wrapper = 'mark', cssClass = '') {
   let open = `<${wrapper}>`;
   let close = `</${wrapper}>`;
   let escapedOpen = `%3C${wrapper}%3E`;
   let escapedClose = `%3C/${wrapper}%3E`;
+
+  if(cssClass) {
+    open = `<${wrapper} class="${cssClass}">`;
+    escapedOpen = `%3C${wrapper} class%3D%22${cssClass}%22%3E`;
+  }
+
   function wrap(context) {
     let c = context.innerHTML;
     let pattern = new RegExp(text, "gi");

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -195,7 +195,7 @@ function initializeSearch(index) {
   searchPageElement ? false : liveSearch();
   passiveSearch();
 
-  highlightSearch(findQuery(), '.post_body', 'mark', 'search-term');
+  highlightSearchTerms(findQuery(), '.post_body', 'mark', 'search-term');
 
   onEscape(clearSearchResults);
 
@@ -208,14 +208,14 @@ function initializeSearch(index) {
   });
 }
 
-function highlightSearch(search, context, wrapper = 'mark', cssClass = '') {
-  let container = document.querySelector(context);
+function highlightSearchTerms(search, context, wrapper = 'mark', cssClass = '') {
+  let container = elem(context);
   let reg = new RegExp("(" + search + ")", "gi");
 
-  function highlightSearchInNode(parentNode, search) {
+  function searchInNode(parentNode, search) {
     forEach(parentNode, function (node) {
       if (node.nodeType === 1) {
-        highlightSearchInNode(node, search);
+        searchInNode(node, search);
       } else if (
         node.nodeType === 3 &&
         reg.test(node.nodeValue)
@@ -229,7 +229,7 @@ function highlightSearch(search, context, wrapper = 'mark', cssClass = '') {
     });
   };
 
-  highlightSearchInNode(container, search);
+  searchInNode(container, search);
 }
 
 window.addEventListener('load', function() {

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -195,7 +195,7 @@ function initializeSearch(index) {
   searchPageElement ? false : liveSearch();
   passiveSearch();
 
-  wrapText(findQuery(), main, 'mark', 'search-term');
+  highlightSearch(findQuery(), main, 'mark', 'search-term');
 
   onEscape(clearSearchResults);
 
@@ -206,6 +206,29 @@ function initializeSearch(index) {
       clearSearchResults();
     }
   });
+}
+
+function highlightSearch(search, container, wrapper = 'mark', cssClass = '') {
+  let reg = new RegExp("(" + search + ")", "gi");
+
+  function highlightSearchInNode(parentNode, search) {
+    forEach(parentNode, function (node) {
+      if (node.nodeType === 1) {
+        highlightSearchInNode(node, search);
+      } else if (
+        node.nodeType === 3 &&
+        reg.test(node.nodeValue)
+      ) {
+        let string = node.nodeValue.replace(reg, `<${wrapper} class="${cssClass}">$1</${wrapper}>`);
+        let span = document.createElement("span");
+        span.dataset.searched = "true";
+        span.innerHTML = string;
+        parentNode.replaceChild(span, node);
+      }
+    });
+  };
+
+  highlightSearchInNode(container, search);
 }
 
 window.addEventListener('load', function() {

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -195,7 +195,7 @@ function initializeSearch(index) {
   searchPageElement ? false : liveSearch();
   passiveSearch();
 
-  wrapText(findQuery(), main);
+  wrapText(findQuery(), main, 'mark', 'search-term');
 
   onEscape(clearSearchResults);
 

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -195,7 +195,7 @@ function initializeSearch(index) {
   searchPageElement ? false : liveSearch();
   passiveSearch();
 
-  highlightSearch(findQuery(), main, 'mark', 'search-term');
+  highlightSearch(findQuery(), '.post_body', 'mark', 'search-term');
 
   onEscape(clearSearchResults);
 
@@ -208,7 +208,8 @@ function initializeSearch(index) {
   });
 }
 
-function highlightSearch(search, container, wrapper = 'mark', cssClass = '') {
+function highlightSearch(search, context, wrapper = 'mark', cssClass = '') {
+  let container = document.querySelector(context);
   let reg = new RegExp("(" + search + ")", "gi");
 
   function highlightSearchInNode(parentNode, search) {


### PR DESCRIPTION
This PR...

## Changes / fixes

- Fixes #328 

I created a new function, `highlightSearchTerms`, because I didn't want to mess up the existing `wrapText` given it's used for other things. However @onweru this is your creation so if you'd rather integrate it back into that single function you certainly could.

This mostly taken from [this blog post and demo](https://xprimiendo.com/en/full-text-search-in-javascript-part-2/). Instead of taking the entire `innerHTML` of the `<main>` element and doing a find-and-replace, it recursively searches the contents of each node -- which means it won't run on things like `href` attributes. Doing it this way also seems to avoid the nested wrapping. 

I constrained it to only highlight terms appearing in `.post_body` (the body text of a post or page) to avoid it highlighting terms in tags.

I don't love the way it wraps the text of a node in which a match is found with a `<span>`, but I couldn't figure out another way to replace a node with something that's just a string (the RegEx result).

## Testing

Running locally, I was testing it on `http://localhost:1313/using-hugo-page-bundles/`, here are some examples:

- http://localhost:1313/using-hugo-page-bundles/?query=hugo
- http://localhost:1313/using-hugo-page-bundles/?query=about
- http://localhost:1313/using-hugo-page-bundles/?query=usepagebundles

The latter two demonstrate that it works when nested in other styles.

## Checklist

_Ensure you have checked off the following before submitting your PR._

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [x] added new dependencies (n/a)
- [x] updated the [docs]() ⚠️ (n/a)