### PR TITLE
from `htmlEscape` to `safeHTML` on attr. `title`

### DIFF
--- a/layouts/partials/figure.html
+++ b/layouts/partials/figure.html
@@ -60,7 +60,7 @@
         src="{{ $fileWeb }}"
       {{ end }}
       {{ with $cap }}
-        title="{{ htmlEscape $cap }}"
+        title="{{ safeHTML $cap }}"
       {{ end }}
     />
 


### PR DESCRIPTION
The attribute `title` of HTML elements **cannot render HTML tags**. Then, the correct is to use safeHTML rather then htmlEscape.
This way we can use HTML tag on `caption` (`featureImageCap`) without rendering escaped HTML (like `&lt;cite&gt;`) on `title` `figure` tag attribute.

This PR...

## Changes / fixes

-

## Screenshots (if applicable)

(prefer animated gif)

## Checklist

_Ensure you have checked off the following before submitting your PR._

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [ ] added new dependencies
- [ ] updated the [docs]() ⚠️
