### PR TITLE
Fix search index url

### DIFF
--- a/assets/js/functions.js
+++ b/assets/js/functions.js
@@ -183,7 +183,7 @@ function parseBoolean(string) {
 };
 
 function forEach(node, callback) {
-  Array.prototype.forEach.call(node.childNodes, callback);
+  node ? Array.prototype.forEach.call(node.childNodes, callback) : false;
 }
 
 function wrapText(text, context, wrapper = 'mark') {

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -233,8 +233,12 @@ function highlightSearchTerms(search, context, wrapper = 'mark', cssClass = '') 
 }
 
 window.addEventListener('load', function() {
-  const pageLanguage = document.documentElement.lang;
-  const searchIndex = `${ pageLanguage === 'en' ? '': pageLanguage}/index.json`;
+  const pageLanguage = elem('body').dataset.lang;
+  const searchIndexLangSlug = pageLanguage === 'en' ? '': `${pageLanguage}/`;
+  const searchIndex = `${searchIndexLangSlug}index.json`;
+
+  console.log(searchIndex, 'search index');
+
   fetch(new URL(baseURL + searchIndex).href)
   .then(response => response.json())
   .then(function(data) {

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -116,7 +116,6 @@ function initializeSearch(index) {
       searchField.addEventListener('input', function() {
         const searchTerm = searchField.value.trim().toLowerCase();
         search(searchTerm, searchScope);
-        // console.log(searchTerm);
       });
 
       if(!searchPageElement) {
@@ -236,9 +235,6 @@ window.addEventListener('load', function() {
   const pageLanguage = elem('body').dataset.lang;
   const searchIndexLangSlug = pageLanguage === 'en' ? '': `${pageLanguage}/`;
   const searchIndex = `${searchIndexLangSlug}index.json`;
-
-  console.log(searchIndex, 'search index');
-
   fetch(new URL(baseURL + searchIndex).href)
   .then(response => response.json())
   .then(function(data) {

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -25,6 +25,7 @@
     data-code="{{ $codeBlockConfig.max }}"
     data-lines="{{ $codeBlockConfig.lines }}"
     id="documentTop"
+    data-lang="{{ .Lang }}"
   >
     {{- partial "header" . }}
     <main>


### PR DESCRIPTION
This PR fixes a regression that causes a `//`  in search index JSON URLs in production.

## Changes / fixes

- Fixes page language lookup
   On Brave browser, the `lang` attribute on the HTML element somehow defaults to `en`, ignoring the value set [here](https://github.com/chipzoller/hugo-clarity/blob/26d1949f05a37739e74154ed28a161f6f96401ab/layouts/_default/baseof.html#L6). This quirk, results in the wrong search index URL in non-english pages. Setting the language via a data attribute avoids this issue. 
- Change how search JSON URL is constructed
- Fixes forEach loop

## Screenshots (if applicable)

(prefer animated gif)

## Checklist

_Ensure you have checked off the following before submitting your PR._

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [ ] added new dependencies
- [ ] updated the [docs]() ⚠️
