### PR TITLE
Hide duplicated posts in sidebar

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -56,10 +56,10 @@
       </ul>
     {{ end }}
 
-    {{- $posts := where (where .Site.RegularPages "Permalink" "!=" .Permalink) "Type" "in" $s.mainSections }}
+    {{- $posts := where .Site.RegularPages "Type" "in" $s.mainSections }}
     {{- $featured := default 8 $s.numberOfFeaturedPosts }}
-    {{- $featured_posts := first $featured (where $posts "Params.featured" true)}}
-    {{- with $featured_posts }}
+    {{- $featuredPosts := first $featured (where $posts "Params.featured" true)}}
+    {{- with $featuredPosts }}
     <h2 class="mt-4">{{ T "featured_posts" }}</h2>
     <ul>
       {{- range . }}
@@ -72,7 +72,7 @@
     <h2 class="mt-4">{{ T "recent_posts" }}</h2>
     <ul class="flex-column">
       {{- $recent := default 8 $s.numberOfRecentPosts }}
-      {{- range first $recent $posts | symdiff $featured_posts }}
+      {{- range first $recent $posts | symdiff $featuredPosts }}
       <li>
         <a href="{{ .Permalink }}" class="nav-link" title="{{ .Title }}">{{ .Title | markdownify }}</a>
       </li>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -34,11 +34,11 @@
     {{- end }}
 
     {{ if .Site.Params.sidebardisclaimer }}
-      <div class="sidebardisclaimer"> 
-        <h2 class="mt-4">Disclaimer</h2> 
+      <div class="sidebardisclaimer">
+        <h2 class="mt-4">Disclaimer</h2>
         {{ .Site.Params.disclaimerText }}
-      </div> 
-    {{ end }}  
+      </div>
+    {{ end }}
 
     {{- $relatedInSidebar := true }}
     {{- if eq $s.showRelatedInSidebar false }}
@@ -58,7 +58,8 @@
 
     {{- $posts := where (where .Site.RegularPages "Permalink" "!=" .Permalink) "Type" "in" $s.mainSections }}
     {{- $featured := default 8 $s.numberOfFeaturedPosts }}
-    {{- with first $featured (where $posts "Params.featured" true)}}
+    {{- $featured_posts := first $featured (where $posts "Params.featured" true)}}
+    {{- with $featured_posts }}
     <h2 class="mt-4">{{ T "featured_posts" }}</h2>
     <ul>
       {{- range . }}
@@ -71,7 +72,7 @@
     <h2 class="mt-4">{{ T "recent_posts" }}</h2>
     <ul class="flex-column">
       {{- $recent := default 8 $s.numberOfRecentPosts }}
-      {{- range first $recent $posts }}
+      {{- range first $recent $posts | symdiff $featured_posts }}
       <li>
         <a href="{{ .Permalink }}" class="nav-link" title="{{ .Title }}">{{ .Title | markdownify }}</a>
       </li>


### PR DESCRIPTION
This PR...

## Changes / fixes

- No longer list duplicated posts in both the recent posts list and the featured list
- Fix currently viewing post won't be listed in the sidebar lists issue (#19)

## Screenshots (if applicable)

![PR](https://user-images.githubusercontent.com/6011839/180852438-2f0aa16b-bcb2-4c3f-a24a-cc5cad276eca.png)

## Checklist

_Ensure you have checked off the following before submitting your PR._

- [v] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [v] added new dependencies
- [v] updated the [docs]() ⚠️
