### PR TITLE
Add pinning featured posts option

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ These options set global values that some pages or all pages in the site use by 
 | comments                   | boolean                     | yes                 |
 | numberOfRecentPosts        | integer                     | no                  |
 | numberOfFeaturedPosts      | integer                     | no                  |
+| pinFeatured                | boolean                     | no                  |
+| numberOfPinnedPosts        | integer                     | no                  |
 | dateFormat                 | string                      | no                  |
 | enableMathNotation         | boolean                     | yes                 |
 | customFonts                | boolean                     | no                  |
@@ -798,13 +800,13 @@ You can override these setting from each post individually. For example, you may
 
  If you wish use [Utterances](https://github.com/utterance/utterances) comments on your site, you'll need to perform the following:
 
- * Ensure you have a GitHub public repository, which you've granted permissions to the [Utterances GitHub App](https://github.com/apps/utterances). 
+ * Ensure you have a GitHub public repository, which you've granted permissions to the [Utterances GitHub App](https://github.com/apps/utterances).
  * Comment out the line for `disqusShortname = ""` in the `/config/_default/config.toml` file.
  * Set `comments = true` in the `/config/_default/params.toml` file.
  * Configure the utterances parameters in the `/config/_default/params.toml` file.
 
  Utterances is loaded in the `comments.html` partial by referring to the `utterances.html` partial.   Since `single.html` layout loads comments if comments are enabled, you must ensure *both* the `comments` and `utterances` parameters are configured.
- 
+
 
 
 
@@ -925,3 +927,9 @@ __Search Scope__
 - Searching outside a section will search the entire site.
 
      For example, with the above setup, searching from the homepage will produce results from the entire site.
+
+### Pinning Featured Posts
+
+This allows you to show the featured posts at the top of the post list.
+
+Using the site configuration option `pinFeatured` to enable/disable it, and the option `numberOfPinnedPosts` to control how many posts to be pinned.

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -105,11 +105,17 @@ languageMenuName = "🌐"
 # utterancesTheme = "github-light" # Default: github-dark
 # utterancesIssueTerm = "pathname" # Default: pathname
 
-# Maximum number of recent posts.
+# Maximum number of recent posts. (default: 8)
 # numberOfRecentPosts = 8
 
-# Maximum number of featured posts.
+# Maximum number of featured posts. (default: 8)
 # numberOfFeaturedPosts = 8
+
+# Pin featured posts in list.
+# pinFeatured = true
+
+# Maximum number of pinned featured posts. (default: 8)
+# numberOfPinnedPosts = 8
 
 # Date format. Checkout https://gohugo.io/functions/format/#hugo-date-and-time-templating-reference for details.
 # dateFormat = "2006-01-02" # Default to "Jan 2, 2006".

--- a/layouts/partials/archive.html
+++ b/layouts/partials/archive.html
@@ -2,6 +2,13 @@
 {{ if .IsHome }}
   {{ $pages = where site.RegularPages "Type" "in" site.Params.mainSections }}
 {{ end }}
+
+{{ if eq site.Params.pinFeatured true }}
+  {{ $featured := default 8 site.Params.numberOfPinnedPosts }}
+  {{ $featuredPosts := first $featured (where $pages "Params.featured" true)}}
+  {{ $normalPosts := $pages | symdiff $featuredPosts }}
+  {{ $pages = $featuredPosts | append $normalPosts }}
+{{ end }}
 <div class="grid-inverse wrap content">
   <div>
     <ul class="posts" id="posts">


### PR DESCRIPTION
This PR...

## Changes / fixes

- Add options for pinning featured posts when listing

## Screenshots (if applicable)

![difference](https://user-images.githubusercontent.com/6011839/180838200-c152d5a9-7268-476a-b8c0-e47c141834dc.png)


## Checklist

_Ensure you have checked off the following before submitting your PR._

- [v] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [v] added new dependencies
- [v] updated the [docs]() ⚠️
