### PR TITLE
Mitigate search results bug

### DIFF
--- a/assets/js/functions.js
+++ b/assets/js/functions.js
@@ -186,6 +186,15 @@ function forEach(node, callback) {
   node ? Array.prototype.forEach.call(node.childNodes, callback) : false;
 }
 
+function findQuery(query = 'query') {
+  const urlParams = new URLSearchParams(window.location.search);
+  if(urlParams.has(query)){
+    let c = urlParams.get(query);
+    return c;
+  }
+  return "";
+}
+
 function wrapText(text, context, wrapper = 'mark') {
   let open = `<${wrapper}>`;
   let close = `</${wrapper}>`;

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -130,15 +130,6 @@ function initializeSearch(index) {
     }
   }
 
-  function findQuery(query = 'query') {
-    const urlParams = new URLSearchParams(window.location.search);
-    if(urlParams.has(query)){
-      let c = urlParams.get(query);
-      return c;
-    }
-    return "";
-  }
-
   function passiveSearch() {
     if(searchPageElement) {
       const searchTerm = findQuery();
@@ -208,27 +199,32 @@ function initializeSearch(index) {
 }
 
 function highlightSearchTerms(search, context, wrapper = 'mark', cssClass = '') {
-  let container = elem(context);
-  let reg = new RegExp("(" + search + ")", "gi");
+  const query = findQuery()
+  if(query){
 
-  function searchInNode(parentNode, search) {
-    forEach(parentNode, function (node) {
-      if (node.nodeType === 1) {
-        searchInNode(node, search);
-      } else if (
-        node.nodeType === 3 &&
-        reg.test(node.nodeValue)
-      ) {
-        let string = node.nodeValue.replace(reg, `<${wrapper} class="${cssClass}">$1</${wrapper}>`);
-        let span = document.createElement("span");
-        span.dataset.searched = "true";
-        span.innerHTML = string;
-        parentNode.replaceChild(span, node);
-      }
-    });
-  };
+    let container = elem(context);
+    let reg = new RegExp("(" + search + ")", "gi");
 
-  searchInNode(container, search);
+    function searchInNode(parentNode, search) {
+      forEach(parentNode, function (node) {
+        if (node.nodeType === 1) {
+          searchInNode(node, search);
+        } else if (
+          node.nodeType === 3 &&
+          reg.test(node.nodeValue)
+        ) {
+          let string = node.nodeValue.replace(reg, `<${wrapper} class="${cssClass}">$1</${wrapper}>`);
+          let span = document.createElement("span");
+          span.dataset.searched = "true";
+          span.innerHTML = string;
+          parentNode.replaceChild(span, node);
+        }
+      });
+    };
+
+    searchInNode(container, search);
+
+  }
 }
 
 window.addEventListener('load', function() {


### PR DESCRIPTION
This PR...

## Changes / fixes

This PR addresses the worst of #341, and we could decide that it constitutes a fix. I think the search results highlighting could still be improved, but with this PR it's no longer catastrophically bad nor affecting the site outside of search functions.

This PR ensures that the `highlightSearchTerms()` function, which is what causes all the extra `<span>`s and `<mark>`s, is _only_ run when a query exists; that is only when you click through to a page when performing a search. For most sites (unless most visitors are constantly performing searches) this will mean a big improvement.

Functionally this is pretty basic; it moves `findQuery()` to the `functions.js` file so it can be accessed outside of the search function it was in, and then tests if it returns anything before running `highlightSearchTerms()`.

This is a somewhat naive fix, as it simply tests whether a query exists in the URL and applies the highlighting if it does. A site might be using queries for things besides search functions, though. If there's a better way to test "is a search being performed?" @onweru I'm open to ideas.

## Screenshots (if applicable)

The bug, and the fix, are not visible when browsing the site unless the end user has made `<mark>` elements visible even when they are empty. Consequently these screenshots are all of the code that is generated.

Before the fix, on a post where no search has been performed (this is the main bug):

![before-nosearch](https://user-images.githubusercontent.com/79733/181635572-9dbb1df7-2786-4dac-ab0e-2e0345d14f23.png)

Before the fix, where a search for "Hugo" has been performed and we've clicked through to that same post:

![before-withsearch](https://user-images.githubusercontent.com/79733/181635691-ee9ff2f2-3519-49d8-b7bd-ef05cd39774c.png)

After the fix, on a post where no search has been performed (bug fixed):

![after-nosearch](https://user-images.githubusercontent.com/79733/181635755-5157b858-ef69-46ba-9e0d-7ea84d88a306.png)

After the fix, where a search for "Hugo" has been performed and we've clicked through to that same post (no change):

![after-withsearch](https://user-images.githubusercontent.com/79733/181635808-2cd4a708-a5fb-40aa-9f64-df8bc91803d6.png)

## Checklist

_Ensure you have checked off the following before submitting your PR._

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [n/a] added new dependencies
- [n/a] updated the [docs]() ⚠️
