### PR TITLE
Remove config suffix from image alt attribute text

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -300,6 +300,9 @@ function fileClosure(){
         // Insert caption
         image.insertAdjacentHTML('afterend', desc.outerHTML);
       }
+
+      // Persist modified alt to image element
+      image.alt = alt
     });
 
     hljs.initHighlightingOnLoad();


### PR DESCRIPTION
The configuration suffix that is appended to an image's _alt_ attribute text (to inline, float, add custom classes etc. to the image) is not removed after being used. See the attached screenshot.



<!--- Please provide a general summary of your changes in the title above. If GitHub has inserted "Signed-off-by" you can remove it if you like. -->

## Pull Request type

<!-- To ensure we're able to review your PR quickly, limit your pull request to one type of change. Submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bug-fix
- [ ] Feature (functionality, design, translations, etc.)
- [ ] Documentation change
- [ ] Project management (tests, CI, GitHub configuration, etc.)
- [ ] Other (please describe):

## Current state

<!-- Please describe the current behavior, content, or docs that you are modifying -- or link to relevant issue(s). -->

Issue Number(s): 

## Proposed changes

In the `populateAlt(images)` function the extra information is removed from _alt_, but the clean _alt_ text is not persisted back to the image element.

Persist the modified/clean _alt_ text to the image element with:

```javascript
image.alt = alt
```

<!-- Please describe the changes this PR makes. -->

## Screenshots, if applicable

![img-alt-issue](https://user-images.githubusercontent.com/987149/208218770-c4e69152-a629-4e5c-9c09-76c19af95387.png)

<!-- For visual changes to the theme, this is required. -->

## Checklist

<!-- Ensure you've completed the following items, as appropriate, before submitting your PR. -->

- [x] **Bug-fixes and new features:** I have tested locally with the [latest release of Hugo extended](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance).
- [x] **Bug-fixes, new features, and doc changes:** I have updated the relevant documentation as part of this PR.
- [x] **All PRs:** I have [signed off](https://github.com/chipzoller/hugo-clarity/blob/master/CONTRIBUTING.md#how-to-submit-a-pull-request) (using `git commit -s ...`), or if not possible due to developer environment constraints, will comment below confirming that I am adhering to the [Developer Certificate of Origin](https://probot.github.io/apps/dco/).
