### PR TITLE
Added support for Utterances labeling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -814,7 +814,7 @@ You can override these setting from each post individually. For example, you may
 
 #### Utterances Commenting Support
 
- If you wish use [Utterances](https://github.com/utterance/utterances) comments on your site, you'll need to perform the following:
+If you wish use [Utterances](https://github.com/utterance/utterances) comments on your site, you'll need to perform the following:
 
  * Ensure you have a GitHub public repository, which you've granted permissions to the [Utterances GitHub App](https://github.com/apps/utterances).
  * Comment out the line for `disqusShortname = ""` in the `/config/_default/config.toml` file.
@@ -822,7 +822,7 @@ You can override these setting from each post individually. For example, you may
  * Configure the utterances parameters in the `/config/_default/params.toml` file.
  * Optionally, you can choose a label that will be assigned to all issues created by Utterances. The label must exist in your Github repository, as Utterances cannot attach labels that do not exist. Configure `utterancesLabel` parameter in `/config/_default/params.toml` file, after you have added a label to your Github repository Issues labels. Labels are case sensitive and support Emoji in label names. ✨💬✨
 
- Utterances is loaded in the `comments.html` partial by referring to the `utterances.html` partial.   Since `single.html` layout loads comments if comments are enabled, you must ensure *both* the `comments` and `utterances` parameters are configured.
+Utterances is loaded in the `comments.html` partial by referring to the `utterances.html` partial.   Since `single.html` layout loads comments if comments are enabled, you must ensure *both* the `comments` and `utterances` parameters are configured.
 
 
 

--- a/README.md
+++ b/README.md
@@ -820,6 +820,7 @@ You can override these setting from each post individually. For example, you may
  * Comment out the line for `disqusShortname = ""` in the `/config/_default/config.toml` file.
  * Set `comments = true` in the `/config/_default/params.toml` file.
  * Configure the utterances parameters in the `/config/_default/params.toml` file.
+ * Optionally, you can choose a label that will be assigned to all issues created by Utterances. The label must exist in your Github repository, as Utterances cannot attach labels that do not exist. Configure `utterancesLabel` parameter in `/config/_default/params.toml` file, after you have added a label to your Github repository Issues labels. Labels are case sensitive and support Emoji in label names. ✨💬✨
 
  Utterances is loaded in the `comments.html` partial by referring to the `utterances.html` partial.   Since `single.html` layout loads comments if comments are enabled, you must ensure *both* the `comments` and `utterances` parameters are configured.
 

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -103,8 +103,9 @@ languageMenuName = "🌐"
 # comments = false
 
 # Enable or disable Utterances (https://github.com/utterance/utterances) Github Issue-Based Commenting
-# utterances = true  #Run the utterances script in the single.html layout to load https://utteranc.es comments
+# utterances = true  # Run the utterances script in the single.html layout to load https://utteranc.es comments
 # utterancesRepo = "GHUsername/Repository.Name" # Utterances is enabled when this param is set
+# utterancesLabel = "blog comments ✨💬✨" # The label needs to be manually added to your Github repository issues before configuring here
 # utterancesTheme = "github-light" # Default: github-dark
 # utterancesIssueTerm = "pathname" # Default: pathname
 

--- a/layouts/partials/utterances.html
+++ b/layouts/partials/utterances.html
@@ -3,6 +3,9 @@
          repo="{{.Site.Params.utterancesRepo}}"
          issue-term="{{.Site.Params.utterancesIssueTerm | default "pathname"}}"
          theme="{{.Site.Params.utterancesTheme | default "github-dark"}}"
+         {{ if .Site.Params.utterancesLabel }}
+         label="{{.Site.Params.utterancesLabel | default "comments"}}"
+         {{ end }}
          crossorigin="anonymous"
          async>
  </script>


### PR DESCRIPTION
All blog posts created by Utterances will be labeled with a custom pre-defined label. The label needs to be manually added to your Github repository Issues labels.

See more details in Utterances documentation:
https://utteranc.es/#heading-issue-label



<!--- Please provide a general summary of your changes in the title above. If GitHub has inserted "Signed-off-by" you can remove it if you like. -->

## Pull Request type

<!-- To ensure we're able to review your PR quickly, limit your pull request to one type of change. Submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bug-fix
- [x] Feature (functionality, design, translations, etc.)
- [ ] Documentation change
- [ ] Project management (tests, CI, GitHub configuration, etc.)
- [ ] Other (please describe):

## Current state

<!-- Please describe the current behavior, content, or docs that you are modifying -- or link to relevant issue(s). -->

Issue Number(s): 

## Proposed changes

<!-- Please describe the changes this PR makes. -->

## Screenshots, if applicable

<!-- For visual changes to the theme, this is required. -->

## Checklist

<!-- Ensure you've completed the following items, as appropriate, before submitting your PR. -->

- [x] **Bug-fixes and new features:** I have tested locally with the [latest release of Hugo extended](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance).
- [x] **Bug-fixes, new features, and doc changes:** I have updated the relevant documentation as part of this PR.
- [x] **All PRs:** I have [signed off](https://github.com/chipzoller/hugo-clarity/blob/master/CONTRIBUTING.md#how-to-submit-a-pull-request) (using `git commit -s ...`), or if not possible due to developer environment constraints, will comment below confirming that I am adhering to the [Developer Certificate of Origin](https://probot.github.io/apps/dco/).
