### PR TITLE
add noindex parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,6 @@ These options set global values that some pages or all pages in the site use by 
 | showRelatedInSidebar       | boolean                     | no                  |
 | footerLogo                 | string                      | N/A                 |
 | enableSearch               | boolean                     | N/A                 |
-| noindex                    | boolean                     | N/A                 |
 
 ### Page Parameters
 
@@ -296,6 +295,7 @@ These options can be set from a page [frontmatter](https://gohugo.io/content-man
 | sidebar              | boolean            | N/A              |
 | singleColumn         | boolean            | N/A              |
 | showRelatedInArticle | boolean            | N/A              |
+| noindex              | boolean            | N/A              |
 
 ### Modify Menus
 

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ These options set global values that some pages or all pages in the site use by 
 | showRelatedInSidebar       | boolean                     | no                  |
 | footerLogo                 | string                      | N/A                 |
 | enableSearch               | boolean                     | N/A                 |
+| noindex                    | boolean                     | N/A                 |
 
 ### Page Parameters
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -10,6 +10,9 @@
 {{- end }}
 <title>{{ with $title }}{{ . }} {{ $separator }} {{ end }}{{ .Site.Title }}</title>
 <meta charset="utf-8">
+{{ if .Params.noindex }}
+<meta name="robots" content="noindex" /> 
+{{ end }}
 {{- with $params.ga_verify }}
   <meta name="google-site-verification" content="{{ . }}">
 {{- end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -11,7 +11,7 @@
 <title>{{ with $title }}{{ . }} {{ $separator }} {{ end }}{{ .Site.Title }}</title>
 <meta charset="utf-8">
 {{ if .Params.noindex }}
-<meta name="robots" content="noindex" /> 
+<meta name="robots" content="noindex" />
 {{ end }}
 {{- with $params.ga_verify }}
   <meta name="google-site-verification" content="{{ . }}">


### PR DESCRIPTION
This PR adds the possibility to set the `noindex` meta parameter in order to preventing search engine from indexing a particular post or page.

To enable it, the following line needs to be added to the front matter:

```yaml
noindex: true
```

Successfully tested on one of my websites.

## Pull Request type

- [ ] Bug-fix
- [x] Feature (functionality, design, translations, etc.)
- [ ] Documentation change
- [ ] Project management (tests, CI, GitHub configuration, etc.)
- [ ] Other (please describe):

## Current state

All pages or posts can be indexed by search engines.

Issue Number(s): #465

## Proposed changes

It adds a parameter `noindex` that can be set in the front matter. If set, the following HTML meta tag is set:

```html
<meta name="robots" content="noindex" />
```

## Screenshots, if applicable

![grafik](https://github.com/chipzoller/hugo-clarity/assets/5862725/d088bace-de72-458a-867c-6905a9889613)

## Checklist

<!-- Ensure you've completed the following items, as appropriate, before submitting your PR. -->

- [x] **Bug-fixes and new features:** I have tested locally with the [latest release of Hugo extended](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance).
- [x] **Bug-fixes, new features, and doc changes:** I have updated the relevant documentation as part of this PR.
- [x] **All PRs:** I have [signed off](https://github.com/chipzoller/hugo-clarity/blob/master/CONTRIBUTING.md#how-to-submit-a-pull-request) (using `git commit -s ...`), or if not possible due to developer environment constraints, will comment below confirming that I am adhering to the [Developer Certificate of Origin](https://probot.github.io/apps/dco/).

I work consistent with the Developer Certificate of Origin.