### PR TITLE
Update post-meta.html

### DIFF
--- a/layouts/partials/post-meta.html
+++ b/layouts/partials/post-meta.html
@@ -23,7 +23,7 @@
       {{- if ($scratch.Get "writeSeparator") }}&nbsp;· {{ end }}
       {{- range . }}
         {{- $tag := urlize . -}}
-        <a href='{{ absLangURL (printf "tags/%s/" $tag) }}' title="{{ . }}" class="post_tag button button_translucent">
+        <a href='{{ absLangURL (printf "tags/%s/" $tag | replace "#" "%23") }}' title="{{ . }}" class="post_tag button button_translucent">
           {{- . }}
         </a>
       {{- end }}


### PR DESCRIPTION
Fix the jump error when the URL of a tag in a post-meta has a # in it (extremely effective for a C# tag)



<!--- Please provide a general summary of your changes in the title above. If GitHub has inserted "Signed-off-by" you can remove it if you like. -->

## Pull Request type

<!-- To ensure we're able to review your PR quickly, limit your pull request to one type of change. Submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bug-fix
- [ ] Feature (functionality, design, translations, etc.)
- [ ] Documentation change
- [ ] Project management (tests, CI, GitHub configuration, etc.)
- [ ] Other (please describe):

## Current state

<!-- Please describe the current behavior, content, or docs that you are modifying -- or link to relevant issue(s). -->

Issue Number(s): 

## Proposed changes

<!-- Please describe the changes this PR makes. -->

Fix the jump error when the URL of a tag in a post-meta has a # in it (extremely effective for a C# tag).

## Screenshots, if applicable

<!-- For visual changes to the theme, this is required. -->

## Checklist

<!-- Ensure you've completed the following items, as appropriate, before submitting your PR. -->

- [x] **Bug-fixes and new features:** I have tested locally with the [latest release of Hugo extended](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance).
- [x] **Bug-fixes, new features, and doc changes:** I have updated the relevant documentation as part of this PR.
- [x] **All PRs:** I have [signed off](https://github.com/chipzoller/hugo-clarity/blob/master/CONTRIBUTING.md#how-to-submit-a-pull-request) (using `git commit -s ...`), or if not possible due to developer environment constraints, will comment below confirming that I am adhering to the [Developer Certificate of Origin](https://probot.github.io/apps/dco/).
