### PR TITLE
Umami Fix to allow self-hosted configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,10 @@ If using Matomo Analytics, configure the `matomo_analytics` global parameters in
 
 `matomoSiteID`  Default is set to 1, change this to the siteid being tracked
 
-If using [Umami Analytics](https://umami.is/), uncomment and configure the `umami_data_website_id` global parameter in your site with the data website ID provided in the script by Umami.  It should be in the form of a GUID (# characters):  8-4-4-4-12.  
+If using [Umami Analytics](https://umami.is/), uncomment and configure the following in *params.toml*:
+
+* `umami_data_website_id` - The data website ID provided in the script by Umami.  It should be in the form of a GUID (# characters):  8-4-4-4-12.
+* `umami_script_url` - This is pre-loaded with the cloud-hosted Umami Script URL, but can be changed if you are self-hosting.
 
 > NOTE:  The head partial only loads analytics if the hugo environment is NOT `development`.  
 

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -167,3 +167,4 @@ matomoSiteID = "1" # Default is set to 1, change this to the siteid being tracke
 
 # Umami Analytics -- https://umami.is/
 # umami_data_website_id = "GUID-8-4-4-4-12" # Umami Analytics data website id - GUID format (8-4-4-4-12)
+# umami_script_url = "https://cloud.umami.is/script.js" # Umami Analytics script URL

--- a/layouts/partials/analytics.html
+++ b/layouts/partials/analytics.html
@@ -53,5 +53,5 @@ src='https://{{ default "plausible.io" $plausible.plausibleDomain }}/js/{{ defau
 {{- end }}
 
 {{- with $config.umami_data_website_id }}
-<script defer src="https://cloud.umami.is/script.js" data-website-id="{{ . }}"></script>
+<script defer src="{{ $config.umami_script_url }}" data-website-id="{{ . }}"></script>
 {{- end }}


### PR DESCRIPTION
Fixing the first version of the code to allow self-hosted configurations.


## Pull Request type


Please check the type of change your PR introduces:

- [X] Bug-fix
- [ ] Feature (functionality, design, translations, etc.)
- [x] Documentation change
- [ ] Project management (tests, CI, GitHub configuration, etc.)
- [ ] Other (please describe):

## Current state

Currently, the Umami code in the `analytics.html` partial assumes the cloud-hosted umami script URL and is not configurable.


## Proposed changes

As mentioned in [the previous pull request](https://github.com/chipzoller/hugo-clarity/pull/482#issuecomment-2613811866), umami can be self-hosted.   This PR intends to fix the original PR by making the script hosting URL configurable.

## Screenshots, if applicable

N/A - this is not a visual change.  It alters the analytics partial which loads in the `<head>...</head>` section of HTML.

## Checklist

<!-- Ensure you've completed the following items, as appropriate, before submitting your PR. -->

- [X] **Bug-fixes and new features:** I have tested locally with the [latest release of Hugo extended](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance).
- [X] **Bug-fixes, new features, and doc changes:** I have updated the relevant documentation as part of this PR.
- [X] **All PRs:** I have [signed off](https://github.com/chipzoller/hugo-clarity/blob/master/CONTRIBUTING.md#how-to-submit-a-pull-request) (using `git commit -s ...`), or if not possible due to developer environment constraints, will comment below confirming that I am adhering to the [Developer Certificate of Origin](https://probot.github.io/apps/dco/).
