### PR TITLE
Fix warning about deprecated shortcode 'tweet'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         hugo-version:
           - 'latest'
-          - '0.128.0'
+          - '0.143.1'
     steps:
       - uses: actions/checkout@v4
 

--- a/exampleSite/config/_default/menus/menu.en.toml
+++ b/exampleSite/config/_default/menus/menu.en.toml
@@ -19,8 +19,8 @@
   url = "https://www.linkedin.com/"
 [[main]]
   parent = "Links"
-  name = "Twitter"
-  url = "https://twitter.com/"
+  name = "X"
+  url = "https://x.com/"
 
 [[main]]
   name = "About"
@@ -35,9 +35,9 @@
   weight = 1
   url = "https://github.com/#"
 [[social]]
-  name = "twitter"
+  name = "X"
   weight = 2
-  url = "https://twitter.com/#"
+  url = "https://x.com/#"
 [[social]]
   name = "linkedin"
   weight = 3

--- a/exampleSite/config/_default/menus/menu.pt.toml
+++ b/exampleSite/config/_default/menus/menu.pt.toml
@@ -19,8 +19,8 @@
   url = "https://www.linkedin.com/"
 [[main]]
   parent = "Links"
-  name = "Twitter"
-  url = "https://twitter.com/"
+  name = "X"
+  url = "https://x.com/"
 
 [[main]]
   name = "Sobre"

--- a/exampleSite/content/post/rich-content.md
+++ b/exampleSite/content/post/rich-content.md
@@ -11,7 +11,7 @@ thumbnail = "images/dollar.png"
 
 +++
 
-Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-management/shortcodes/#use-hugo-s-built-in-shortcodes) for rich content, along with a [Privacy Config](https://gohugo.io/about/hugo-and-gdpr/) and a set of Simple Shortcodes that enable static and no-JS versions of various social media embeds.
+Hugo ships with several [Embedded Shortcodes](https://gohugo.io/content-management/shortcodes/#embedded) for rich content, along with a [Privacy Config](https://gohugo.io/about/hugo-and-gdpr/) and a set of Simple Shortcodes that enable static and no-JS versions of various social media embeds.
 <!--more-->
 ---
 
@@ -29,11 +29,11 @@ Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-manageme
 
 ---
 
-## Twitter Simple Shortcode
+## X Simple Shortcode
 
-{{< tweet user="SanDiegoZoo" id="1453110110599868418" >}}
+{{< x user="SanDiegoZoo" id="1453110110599868418" >}}
 
-See documentation https://gohugo.io/content-management/shortcodes/#tweet for more details
+See shortcode [documentation](https://gohugo.io/shortcodes/x/) for more details.
 
 <br>
 


### PR DESCRIPTION
When running example site with latest hugo version 0.143.1, a warning is shown:

```
WARN  The "twitter", "tweet", and "twitter_simple" shortcodes were deprecated in v0.142.0 and will be removed in a future release.
Please use the "x" shortcode instead.
```

This PR fixes this issue.