### PR TITLE
mark scalable images as they load

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -308,28 +308,25 @@ function fileClosure(){
     hljs.initHighlightingOnLoad();
   }
 
-  function largeImages(baseParent, images = []) {
-    if(images) {
-      images.forEach(function(image) {
-        window.setTimeout(function(){
-          let actualWidth = image.naturalWidth;
-          let parentWidth = baseParent.offsetWidth;
-          let actionableRatio = actualWidth / parentWidth;
+ function mark_image_as_scalable(baseParent, image) {
+  let actualWidth = image.naturalWidth;
+  let parentWidth = baseParent.offsetWidth;
+  let actionableRatio = actualWidth / parentWidth;
 
-          if (actionableRatio > 1) {
-            pushClass(image.parentNode.parentNode, imageScalableClass);
-            image.parentNode.parentNode.dataset.scale = actionableRatio;
-          }
-        }, 100)
-      });
-    }
+  if (actionableRatio > 1) {
+    pushClass(image.parentNode.parentNode, imageScalableClass);
+    image.parentNode.parentNode.dataset.scale = actionableRatio;
   }
+ }
 
   (function AltImage() {
     let post = elem('.post_content');
     let images = post ? post.querySelectorAll('img') : false;
     images ? populateAlt(images) : false;
-    largeImages(post, images);
+
+    images.forEach((image) => image.addEventListener('load', (e) => {
+      mark_image_as_scalable(post, image);
+    }));
   })();
 
   doc.addEventListener('click', function(event) {


### PR DESCRIPTION
Signed-off-by: weru <fromweru@gmail.com>



<!--- Please provide a general summary of your changes in the title above. If GitHub has inserted "Signed-off-by" you can remove it if you like. -->
Images are now marked as scalable when they actually load, not when the page first loads. I tested with 3 large screenshots distributed across [this long markdown](https://github.com/chipzoller/hugo-clarity/blob/master/exampleSite/content/post/markdown-syntax.md) page.

## Pull Request type

<!-- To ensure we're able to review your PR quickly, limit your pull request to one type of change. Submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bug-fix
- [ ] Feature (functionality, design, translations, etc.)
- [ ] Documentation change
- [ ] Project management (tests, CI, GitHub configuration, etc.)
- [ ] Other (please describe):

## Current state

<!-- Please describe the current behavior, content, or docs that you are modifying -- or link to relevant issue(s). -->

Issue Number(s):  #453 

## Proposed changes

<!-- Please describe the changes this PR makes. -->

## Screenshots, if applicable

<!-- For visual changes to the theme, this is required. -->

## Checklist

<!-- Ensure you've completed the following items, as appropriate, before submitting your PR. -->

- [x] **Bug-fixes and new features:** I have tested locally with the [latest release of Hugo extended](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance).
- [x] **Bug-fixes, new features, and doc changes:** I have updated the relevant documentation as part of this PR.
- [x] **All PRs:** I have [signed off](https://github.com/chipzoller/hugo-clarity/blob/master/CONTRIBUTING.md#how-to-submit-a-pull-request) (using `git commit -s ...`), or if not possible due to developer environment constraints, will comment below confirming that I am adhering to the [Developer Certificate of Origin](https://probot.github.io/apps/dco/).
