### PR TITLE
Add Mastodon identity verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ These options set global values that some pages or all pages in the site use by 
 | enableSearch               | boolean                     | N/A                 |
 | blogDir                    | string                      | no                  |
 | cdn                        | map                         | no                  |
+| mastodon                   | boolean                     | no                  |
 
 ### Page Parameters
 
@@ -348,7 +349,22 @@ If using [Umami Analytics](https://umami.is/), uncomment and configure the follo
 * `umami_data_website_id` - The data website ID provided in the script by Umami.  It should be in the form of a GUID (# characters):  8-4-4-4-12.
 * `umami_script_url` - This is pre-loaded with the cloud-hosted Umami Script URL, but can be changed if you are self-hosting.
 
-> NOTE:  The head partial only loads analytics if the hugo environment is NOT `development`.  
+> NOTE:  The head partial only loads analytics if the hugo environment is NOT `development`.
+
+### Mastodon verification
+
+When you link to this website from your profile, Mastodon will
+check that the website links back to your profile and show a visual indicator on it.
+So you can verify your identity on Mastodon.
+
+Edit `params.toml` to adjust your site configuration.
+
+```toml
+[mastodon]
+verify = false               # To enable Mastodon verification change to `true`.
+instance = "mastodon.social" # Set to Matodon instance name
+username = "johndoe"         # Set to Matodon username (without instance name)
+```
 
 ### Blog directory
 

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -68,7 +68,7 @@ enableMathNotation = false
 
 # directory(s) where your articles are located
 mainSections = [
-  "post",
+    "post",
 ] # see config details here https://gohugo.io/functions/where/#mainsections
 
 # Label Non inline images on an article body
@@ -172,8 +172,13 @@ matomoSiteID = "1"                  # Default is set to 1, change this to the si
 # umami_data_website_id = "GUID-8-4-4-4-12" # Umami Analytics data website id - GUID format (8-4-4-4-12)
 # umami_script_url = "https://cloud.umami.is/script.js" # Umami Analytics script URL
 
-[cdn] # a CDN shortcode to generate links for your images and files in buckets such as B2, S3, etc.  
+[cdn] # a CDN shortcode to generate links for your images and files in buckets such as B2, S3, etc.
 url = "https://some.url.scheme/"  # your base CDN url such as "https://images.site.com/" (including the trailing slash)
 imagesdir = "images/"             # Include trailing slash -- this is where you store images
 filesdir = "files/"               # Include trailing slash -- this is where you store files to be downloaded
 hotlinkdir = "images/hotlink-ok/" # Include trailing slash -- this is where you store images that are allowed to be hotlinked
+
+[mastodon]
+verify = false               # To enable Mastodon verification change to `true`.
+instance = "mastodon.social" # Set to Matodon instance name
+username = "johndoe"         # Set to Matodon username (without instance name)

--- a/layouts/partials/follow.html
+++ b/layouts/partials/follow.html
@@ -2,13 +2,23 @@
 .Site.Menus.social }} {{- with $social }} {{- $items = . }} {{- end }}
 <div class="follow">
     {{- range $items }} {{- $url := .URL }} {{- $label := lower .Name }} {{-
-    $verify := false }} {{- if eq $social nil }} {{ $url = .url }} {{ $label =
-    lower .item }} {{ $verify = .verify }} {{- else }} {{ $verify =
-    .Params.verify }} {{- end }} {{- if and (eq (hasPrefix $url $base) false)
-    (eq (hasPrefix $url "http") false) }} {{ $url = absLangURL $url }} {{- end
-    }}
+    $verify := false }}
+
+    <!-- Debug info -->
+    <!-- {{ printf "Processing item: %s" $label }} -->
+
+    {{- if eq $social nil }} {{ $url = .url }} {{ $label = lower .item }} {{-
+    with .verify }} {{ $verify = . }}
+    <!-- {{ printf "Found verify property in data: %t" $verify }} -->
+    {{- end }} {{- else }} {{- with .Params.verify }} {{ $verify = . }}
+    <!-- {{ printf "Found verify property in menu: %t" $verify }} -->
+    {{- end }} {{- end }} {{- if and (eq (hasPrefix $url $base) false) (eq
+    (hasPrefix $url "http") false) }} {{ $url = absLangURL $url }} {{- end }}
+
     <a href="{{ $url }}"> {{ partial "sprite" (dict "icon" $label) }} </a>
+
     {{- if and (eq $label "mastodon") $verify }}
+    <!-- {{ printf "Rendering Mastodon verification link" }} -->
     <a rel="me" href="{{ $url }}">Mastodon</a>
     {{- end }} {{- end }} {{- partialCached "mode" . }}
 </div>

--- a/layouts/partials/follow.html
+++ b/layouts/partials/follow.html
@@ -2,15 +2,19 @@
 .Site.Menus.social }} {{- with $social }} {{- $items = . }} {{- end }}
 <div class="follow">
     {{- range $items }} {{- $url := .URL }} {{- $label := lower .Name }} {{-
-    $verify := false }} {{- if eq $social nil }} {{ $url = .url }} {{ $label =
-    lower .item }} {{ $verify = .verify }} {{- else }} {{ $verify =
-    .Params.verify }} {{- end }} {{- if and (eq (hasPrefix $url $base) false)
-    (eq (hasPrefix $url "http") false) }} {{ $url = absLangURL $url }} {{- end
-    }} {{- if and (eq $label "mastodon") ($verify) }}
+    $verify := false }} {{- if eq $social nil }} {{- $url = .url }} {{- $label =
+    lower .item }} {{- if isset . "verify" }} {{- $verify = .verify }} {{- end
+    }} {{- else }} {{- if isset .Params "verify" }} {{- $verify = .Params.verify
+    }} {{- end }} {{- end }} {{- if and (eq (hasPrefix $url $base) false) (eq
+    (hasPrefix $url "http") false) }} {{- $url = absLangURL $url }} {{- end }}
+    {{- if and (eq $label "mastodon") $verify }}
     <a rel="me" href="{{ $url }}">
-        {{ partial "sprite" (dict "icon" $label) }} Mastodon
+        <svg class="icon">
+            <title>mastodon</title>
+            <use xlink:href="#mastodon"></use>
+        </svg>
+        Mastodon
     </a>
-    {{- else }}
-    <a href="{{ $url }}"> {{ partial "sprite" (dict "icon" $label) }} </a>
-    {{- end }} {{- end }} {{- partialCached "mode" . }}
+    {{- else }} {{- partial "sprite" (dict "icon" $label) }} {{- end }} {{- end
+    }} {{- partialCached "mode" . }}
 </div>

--- a/layouts/partials/follow.html
+++ b/layouts/partials/follow.html
@@ -1,23 +1,15 @@
-{{- $base := absURL "" }}
-{{- $items := .Site.Data.social }}
-{{- $social := .Site.Menus.social }}
-{{- with $social }}
-  {{- $items = . }}
-{{- end }}
-<div class='follow'>
-  {{- range $items }}
-  {{- $url := .URL }}
-  {{- $label := lower .Name }}
-  {{- if eq $social nil }}
-    {{ $url = .url }}
-    {{ $label = lower .item }}
-  {{- end }}
-  {{- if and (eq (hasPrefix $url $base) false) (eq (hasPrefix $url "http") false) }}
-    {{ $url = absLangURL $url }}
-  {{- end }}
-  <a href="{{ $url }}">
-    {{ partial "sprite" (dict "icon" $label) }}
-  </a>
-  {{- end }}
-  {{- partialCached "mode" . }}
+{{- $base := absURL "" }} {{- $items := .Site.Data.social }} {{- $social :=
+.Site.Menus.social }} {{- with $social }} {{- $items = . }} {{- end }}
+<div class="follow">
+    {{- range $items }} {{- $url := .URL }} {{- $label := lower .Name }} {{- if
+    eq $social nil }} {{ $url = .url }} {{ $label = lower .item }} {{- end }}
+    {{- if and (eq (hasPrefix $url $base) false) (eq (hasPrefix $url "http")
+    false) }} {{ $url = absLangURL $url }} {{- end }} {{- if eq $label
+    "mastodon" }}
+    <a rel="me" href="{{ $url }}">
+        {{ partial "sprite" (dict "icon" $label) }}
+    </a>
+    {{- else }}
+    <a href="{{ $url }}"> {{ partial "sprite" (dict "icon" $label) }} </a>
+    {{- end }} {{- end }} {{- partialCached "mode" . }}
 </div>

--- a/layouts/partials/follow.html
+++ b/layouts/partials/follow.html
@@ -2,19 +2,13 @@
 .Site.Menus.social }} {{- with $social }} {{- $items = . }} {{- end }}
 <div class="follow">
     {{- range $items }} {{- $url := .URL }} {{- $label := lower .Name }} {{-
-    $verify := false }} {{- if eq $social nil }} {{- $url = .url }} {{- $label =
-    lower .item }} {{- if isset . "verify" }} {{- $verify = .verify }} {{- end
-    }} {{- else }} {{- if isset .Params "verify" }} {{- $verify = .Params.verify
-    }} {{- end }} {{- end }} {{- if and (eq (hasPrefix $url $base) false) (eq
-    (hasPrefix $url "http") false) }} {{- $url = absLangURL $url }} {{- end }}
+    $verify := false }} {{- if eq $social nil }} {{ $url = .url }} {{ $label =
+    lower .item }} {{ $verify = .verify }} {{- else }} {{ $verify =
+    .Params.verify }} {{- end }} {{- if and (eq (hasPrefix $url $base) false)
+    (eq (hasPrefix $url "http") false) }} {{ $url = absLangURL $url }} {{- end
+    }}
+    <a href="{{ $url }}"> {{ partial "sprite" (dict "icon" $label) }} </a>
     {{- if and (eq $label "mastodon") $verify }}
-    <a rel="me" href="{{ $url }}">
-        <svg class="icon">
-            <title>mastodon</title>
-            <use xlink:href="#mastodon"></use>
-        </svg>
-        Mastodon
-    </a>
-    {{- else }} {{- partial "sprite" (dict "icon" $label) }} {{- end }} {{- end
-    }} {{- partialCached "mode" . }}
+    <a rel="me" href="{{ $url }}">Mastodon</a>
+    {{- end }} {{- end }} {{- partialCached "mode" . }}
 </div>

--- a/layouts/partials/follow.html
+++ b/layouts/partials/follow.html
@@ -1,10 +1,11 @@
 {{- $base := absURL "" }} {{- $items := .Site.Data.social }} {{- $social :=
 .Site.Menus.social }} {{- with $social }} {{- $items = . }} {{- end }}
 <div class="follow">
-    {{- range $items }} {{- $url := .URL }} {{- $verify := .Verify }} {{- $label
-    := lower .Name }} {{- if eq $social nil }} {{ $url = .url }} {{ $label =
-    lower .item }} {{- end }} {{- if and (eq (hasPrefix $url $base) false) (eq
-    (hasPrefix $url "http") false) }} {{ $url = absLangURL $url }} {{- end }}
+    {{- range $items }} {{- $url := .URL }} {{- $label := lower .Name }} {{
+    $verify = .Params.verify }} {{- if eq $social nil }} {{ $url = .url }} {{
+    $label = lower .item }} {{- end }} {{- if and (eq (hasPrefix $url $base)
+    false) (eq (hasPrefix $url "http") false) }} {{ $url = absLangURL $url }}
+    {{- end }}
     <a href="{{ $url }}"> {{ partial "sprite" (dict "icon" $label) }} </a>
 
     {{- if and (eq $label "mastodon") $verify }}

--- a/layouts/partials/follow.html
+++ b/layouts/partials/follow.html
@@ -17,7 +17,7 @@
 
     <a href="{{ $url }}"> {{ partial "sprite" (dict "icon" $label) }} </a>
 
-    {{- if and (eq $label "mastodon") $verify }}
+    {{- if eq $label "mastodon" }}
     <!-- {{ printf "Rendering Mastodon verification link" }} -->
     <a rel="me" href="{{ $url }}">Mastodon</a>
     {{- end }} {{- end }} {{- partialCached "mode" . }}

--- a/layouts/partials/follow.html
+++ b/layouts/partials/follow.html
@@ -1,14 +1,23 @@
-{{- $base := absURL "" }} {{- $items := .Site.Data.social }} {{- $social :=
-.Site.Menus.social }} {{- with $social }} {{- $items = . }} {{- end }}
-<div class="follow">
-    {{- range $items }} {{- $url := .URL }} {{- $label := lower .Name }} {{
-    $verify = .Params.verify }} {{- if eq $social nil }} {{ $url = .url }} {{
-    $label = lower .item }} {{- end }} {{- if and (eq (hasPrefix $url $base)
-    false) (eq (hasPrefix $url "http") false) }} {{ $url = absLangURL $url }}
-    {{- end }}
-    <a href="{{ $url }}"> {{ partial "sprite" (dict "icon" $label) }} </a>
-
-    {{- if and (eq $label "mastodon") $verify }}
-    <a rel="me" href="{{ $url }}">Mastodon</a>
-    {{- end }} {{- end }} {{- partialCached "mode" . }}
+{{- $base := absURL "" }}
+{{- $items := .Site.Data.social }}
+{{- $social := .Site.Menus.social }}
+{{- with $social }}
+  {{- $items = . }}
+{{- end }}
+<div class='follow'>
+  {{- range $items }}
+  {{- $url := .URL }}
+  {{- $label := lower .Name }}
+  {{- if eq $social nil }}
+    {{ $url = .url }}
+    {{ $label = lower .item }}
+  {{- end }}
+  {{- if and (eq (hasPrefix $url $base) false) (eq (hasPrefix $url "http") false) }}
+    {{ $url = absLangURL $url }}
+  {{- end }}
+  <a href="{{ $url }}">
+    {{ partial "sprite" (dict "icon" $label) }}
+  </a>
+  {{- end }}
+  {{- partialCached "mode" . }}
 </div>

--- a/layouts/partials/follow.html
+++ b/layouts/partials/follow.html
@@ -1,24 +1,13 @@
 {{- $base := absURL "" }} {{- $items := .Site.Data.social }} {{- $social :=
 .Site.Menus.social }} {{- with $social }} {{- $items = . }} {{- end }}
 <div class="follow">
-    {{- range $items }} {{- $url := .URL }} {{- $label := lower .Name }} {{-
-    $verify := false }}
-
-    <!-- Debug info -->
-    <!-- {{ printf "Processing item: %s" $label }} -->
-
-    {{- if eq $social nil }} {{ $url = .url }} {{ $label = lower .item }} {{-
-    with .verify }} {{ $verify = . }}
-    <!-- {{ printf "Found verify property in data: %t" $verify }} -->
-    {{- end }} {{- else }} {{- with .Params.verify }} {{ $verify = . }}
-    <!-- {{ printf "Found verify property in menu: %t" $verify }} -->
-    {{- end }} {{- end }} {{- if and (eq (hasPrefix $url $base) false) (eq
+    {{- range $items }} {{- $url := .URL }} {{- $verify := .Verify }} {{- $label
+    := lower .Name }} {{- if eq $social nil }} {{ $url = .url }} {{ $label =
+    lower .item }} {{- end }} {{- if and (eq (hasPrefix $url $base) false) (eq
     (hasPrefix $url "http") false) }} {{ $url = absLangURL $url }} {{- end }}
-
     <a href="{{ $url }}"> {{ partial "sprite" (dict "icon" $label) }} </a>
 
-    {{- if eq $label "mastodon" }}
-    <!-- {{ printf "Rendering Mastodon verification link" }} -->
+    {{- if and (eq $label "mastodon") $verify }}
     <a rel="me" href="{{ $url }}">Mastodon</a>
     {{- end }} {{- end }} {{- partialCached "mode" . }}
 </div>

--- a/layouts/partials/follow.html
+++ b/layouts/partials/follow.html
@@ -1,13 +1,14 @@
 {{- $base := absURL "" }} {{- $items := .Site.Data.social }} {{- $social :=
 .Site.Menus.social }} {{- with $social }} {{- $items = . }} {{- end }}
 <div class="follow">
-    {{- range $items }} {{- $url := .URL }} {{- $label := lower .Name }} {{- if
-    eq $social nil }} {{ $url = .url }} {{ $label = lower .item }} {{- end }}
-    {{- if and (eq (hasPrefix $url $base) false) (eq (hasPrefix $url "http")
-    false) }} {{ $url = absLangURL $url }} {{- end }} {{- if eq $label
-    "mastodon" }}
+    {{- range $items }} {{- $url := .URL }} {{- $label := lower .Name }} {{-
+    $verify := false }} {{- if eq $social nil }} {{ $url = .url }} {{ $label =
+    lower .item }} {{ $verify = .verify }} {{- else }} {{ $verify =
+    .Params.verify }} {{- end }} {{- if and (eq (hasPrefix $url $base) false)
+    (eq (hasPrefix $url "http") false) }} {{ $url = absLangURL $url }} {{- end
+    }} {{- if and (eq $label "mastodon") ($verify) }}
     <a rel="me" href="{{ $url }}">
-        {{ partial "sprite" (dict "icon" $label) }}
+        {{ partial "sprite" (dict "icon" $label) }} Mastodon
     </a>
     {{- else }}
     <a href="{{ $url }}"> {{ partial "sprite" (dict "icon" $label) }} </a>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,50 +1,64 @@
-{{- $params := site.Params }}
-{{- $separator := default "|" $params.titleSeparator }}
-{{- $title := "" }}
-{{- if and .Title (ne (trim (lower .Site.Title) "") (trim (lower .Title) "")) }}
-  {{- if eq .Kind "taxonomy" }}
-    {{- $title = default .Title ( T (lower .Title) ) }}
-  {{- else }}
-    {{- $title = .Title }}
-  {{- end }}
-{{- end }}
-<title>{{ with $title }}{{ . }} {{ $separator }} {{ end }}{{ .Site.Title }}</title>
-<meta charset="utf-8">
+{{- $params := site.Params }} {{- $separator := default "|"
+$params.titleSeparator }} {{- $title := "" }} {{- if and .Title (ne (trim (lower
+.Site.Title) "") (trim (lower .Title) "")) }} {{- if eq .Kind "taxonomy" }} {{-
+$title = default .Title ( T (lower .Title) ) }} {{- else }} {{- $title = .Title
+}} {{- end }} {{- end }}
+<title>
+    {{ with $title }}{{ . }} {{ $separator }} {{ end }}{{ .Site.Title }}
+</title>
+<meta charset="utf-8" />
 {{ if .Params.noindex }}
 <meta name="robots" content="noindex" />
-{{ end }}
-{{- with $params.ga_verify }}
-  <meta name="google-site-verification" content="{{ . }}">
+{{ end }} {{- with $params.ga_verify }}
+<meta name="google-site-verification" content="{{ . }}" />
 {{- end }}
-<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-{{- if (ne hugo.Environment "development") }}
-  {{- partialCached "analytics" . }}
-{{- end }}
-{{- partial "opengraph" . }}
-{{- partialCached "favicon" . }}
-<link rel="canonical" href="{{ .Permalink }}">
-{{ range .AlternativeOutputFormats -}}
-  {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
-{{ end -}}
+<meta
+    name="viewport"
+    content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+/>
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+{{- if (ne hugo.Environment "development") }} {{- partialCached "analytics" . }}
+{{- end }} {{- partialCached "mastodon" . }} {{- partial "opengraph" . }} {{-
+partialCached "favicon" . }}
+<link rel="canonical" href="{{ .Permalink }}" />
+{{ range .AlternativeOutputFormats -}} {{ printf `<link
+    rel="%s"
+    type="%s"
+    href="%s"
+    title="%s"
+/>` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }} {{ end -}}
 
 <!-- preload assets declaration -->
 <!-- preload main css file -->
 {{ $styles := partialCached "func/getStylesBundle" . }}
-<link rel="preload" href="{{ $styles.Permalink }}" integrity = "{{ $styles.Data.Integrity }}" as="style" crossorigin="anonymous">
+<link
+    rel="preload"
+    href="{{ $styles.Permalink }}"
+    integrity="{{ $styles.Data.Integrity }}"
+    as="style"
+    crossorigin="anonymous"
+/>
 
 <!-- preload main javascript file -->
 {{ $bundle := partialCached "func/getJavascriptBundle" . }}
-<link rel="preload" href="{{ $bundle.Permalink }}" as="script" integrity=
-"{{ $bundle.Data.Integrity }}" crossorigin="anonymous">
+<link
+    rel="preload"
+    href="{{ $bundle.Permalink }}"
+    as="script"
+    integrity="{{ $bundle.Data.Integrity }}"
+    crossorigin="anonymous"
+/>
 
 <!-- link main css file -->
-<link rel="stylesheet" type="text/css" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}" crossorigin="anonymous">
+<link
+    rel="stylesheet"
+    type="text/css"
+    href="{{ $styles.Permalink }}"
+    integrity="{{ $styles.Data.Integrity }}"
+    crossorigin="anonymous"
+/>
 <!-- load all custom css files -->
-{{- with $params.customCSS }}
-  {{- range . -}}
-  <link rel="stylesheet" href="{{ relURL . }}">
-  {{- end }}
-{{- end }}
-
-{{- partial "scripts/google/tag-manager" (dict "noscript" false) }}
+{{- with $params.customCSS }} {{- range . -}}
+<link rel="stylesheet" href="{{ relURL . }}" />
+{{- end }} {{- end }} {{- partial "scripts/google/tag-manager" (dict "noscript"
+false) }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,64 +1,51 @@
-{{- $params := site.Params }} {{- $separator := default "|"
-$params.titleSeparator }} {{- $title := "" }} {{- if and .Title (ne (trim (lower
-.Site.Title) "") (trim (lower .Title) "")) }} {{- if eq .Kind "taxonomy" }} {{-
-$title = default .Title ( T (lower .Title) ) }} {{- else }} {{- $title = .Title
-}} {{- end }} {{- end }}
-<title>
-    {{ with $title }}{{ . }} {{ $separator }} {{ end }}{{ .Site.Title }}
-</title>
-<meta charset="utf-8" />
+{{- $params := site.Params }}
+{{- $separator := default "|" $params.titleSeparator }}
+{{- $title := "" }}
+{{- if and .Title (ne (trim (lower .Site.Title) "") (trim (lower .Title) "")) }}
+  {{- if eq .Kind "taxonomy" }}
+    {{- $title = default .Title ( T (lower .Title) ) }}
+  {{- else }}
+    {{- $title = .Title }}
+  {{- end }}
+{{- end }}
+<title>{{ with $title }}{{ . }} {{ $separator }} {{ end }}{{ .Site.Title }}</title>
+<meta charset="utf-8">
 {{ if .Params.noindex }}
 <meta name="robots" content="noindex" />
-{{ end }} {{- with $params.ga_verify }}
-<meta name="google-site-verification" content="{{ . }}" />
+{{ end }}
+{{- with $params.ga_verify }}
+  <meta name="google-site-verification" content="{{ . }}">
 {{- end }}
-<meta
-    name="viewport"
-    content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-/>
-<meta http-equiv="X-UA-Compatible" content="IE=edge" />
-{{- if (ne hugo.Environment "development") }} {{- partialCached "analytics" . }}
-{{- end }} {{- partialCached "mastodon" . }} {{- partial "opengraph" . }} {{-
-partialCached "favicon" . }}
-<link rel="canonical" href="{{ .Permalink }}" />
-{{ range .AlternativeOutputFormats -}} {{ printf `<link
-    rel="%s"
-    type="%s"
-    href="%s"
-    title="%s"
-/>` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }} {{ end -}}
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+{{- if (ne hugo.Environment "development") }}
+  {{- partialCached "analytics" . }}
+{{- end }}
+{{- partialCached "mastodon" . }}
+{{- partial "opengraph" . }}
+{{- partialCached "favicon" . }}
+<link rel="canonical" href="{{ .Permalink }}">
+{{ range .AlternativeOutputFormats -}}
+  {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+{{ end -}}
 
 <!-- preload assets declaration -->
 <!-- preload main css file -->
 {{ $styles := partialCached "func/getStylesBundle" . }}
-<link
-    rel="preload"
-    href="{{ $styles.Permalink }}"
-    integrity="{{ $styles.Data.Integrity }}"
-    as="style"
-    crossorigin="anonymous"
-/>
+<link rel="preload" href="{{ $styles.Permalink }}" integrity = "{{ $styles.Data.Integrity }}" as="style" crossorigin="anonymous">
 
 <!-- preload main javascript file -->
 {{ $bundle := partialCached "func/getJavascriptBundle" . }}
-<link
-    rel="preload"
-    href="{{ $bundle.Permalink }}"
-    as="script"
-    integrity="{{ $bundle.Data.Integrity }}"
-    crossorigin="anonymous"
-/>
+<link rel="preload" href="{{ $bundle.Permalink }}" as="script" integrity=
+"{{ $bundle.Data.Integrity }}" crossorigin="anonymous">
 
 <!-- link main css file -->
-<link
-    rel="stylesheet"
-    type="text/css"
-    href="{{ $styles.Permalink }}"
-    integrity="{{ $styles.Data.Integrity }}"
-    crossorigin="anonymous"
-/>
+<link rel="stylesheet" type="text/css" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}" crossorigin="anonymous">
 <!-- load all custom css files -->
-{{- with $params.customCSS }} {{- range . -}}
-<link rel="stylesheet" href="{{ relURL . }}" />
-{{- end }} {{- end }} {{- partial "scripts/google/tag-manager" (dict "noscript"
-false) }}
+{{- with $params.customCSS }}
+  {{- range . -}}
+  <link rel="stylesheet" href="{{ relURL . }}">
+  {{- end }}
+{{- end }}
+
+{{- partial "scripts/google/tag-manager" (dict "noscript" false) }}

--- a/layouts/partials/mastodon.html
+++ b/layouts/partials/mastodon.html
@@ -1,0 +1,6 @@
+{{- $config := site.Params }}
+{{- with $config.mastodon }}
+  {{- if .verify }}
+    <a rel="me" href="https://{{ .instance }}/@{{ .username }}">Mastodon</a>
+  {{- end }}
+{{- end }}


### PR DESCRIPTION

<!--- Please provide a general summary of your changes in the title above. If GitHub has inserted "Signed-off-by" you can remove it if you like. -->

## Pull Request type

<!-- To ensure we're able to review your PR quickly, limit your pull request to one type of change. Submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bug-fix
- [x] Feature (functionality, design, translations, etc.)
- [x] Documentation change
- [ ] Project management (tests, CI, GitHub configuration, etc.)
- [ ] Other (please describe):

## Current state

<!-- Please describe the current behavior, content, or docs that you are modifying -- or link to relevant issue(s). -->

Issue Number(s): 

## Proposed changes

It's allow user to verify their identity on Mastodon, with a few lines of config in `param.toml`.

Initial idea was to use `follow.html` layout, however I realize that linking blog's follow with mastodon identity it's not always a case, so I decided to split it into two separe objects.  

## Screenshots, if applicable

<!-- For visual changes to the theme, this is required. -->

## Checklist

<!-- Ensure you've completed the following items, as appropriate, before submitting your PR. -->

- [x] **Bug-fixes and new features:** I have tested locally with the [latest release of Hugo extended](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance).
- [x] **Bug-fixes, new features, and doc changes:** I have updated the relevant documentation as part of this PR.
- [x] **All PRs:** I have [signed off](https://github.com/chipzoller/hugo-clarity/blob/master/CONTRIBUTING.md#how-to-submit-a-pull-request) (using `git commit -s ...`), or if not possible due to developer environment constraints, will comment below confirming that I am adhering to the [Developer Certificate of Origin](https://probot.github.io/apps/dco/).
