### PR TITLE
exampleSite: fix error when running with hugo 0.146.2

### DIFF
--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -3,10 +3,10 @@
     {{ template "_internal/disqus.html" . }}
   {{ end }}
   {{ if .Site.Params.utterances }}
-    {{ template "partials/utterances.html" . }}
+    {{ partial "utterances.html" . }}
   {{ end }}
   {{ if .Site.Params.giscus }}
-    {{ template "partials/giscus.html" . }}
+    {{ partial "giscus.html" . }}
   {{ end }}
   <!-- add custom comments markup here -->
 </div>


### PR DESCRIPTION
When running example site with latest hugo version 0.146.2, errors are thrown:

```
Error: html/template:_partials/comments.html:9:16: no such template "partials/giscus.html"
```

This PR fixes these issues.
For details, see https://github.com/gohugoio/hugo/issues/13582

Please check the type of change your PR introduces:

- [x] Bug-fix

- [x] **Bug-fixes and new features:** I have tested locally with the [latest release of Hugo extended](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance).
- [x] **All PRs:** I have [signed off](https://github.com/chipzoller/hugo-clarity/blob/master/CONTRIBUTING.md#how-to-submit-a-pull-request) (using `git commit -s ...`), or if not possible due to developer environment constraints, will comment below confirming that I am adhering to the [Developer Certificate of Origin](https://probot.github.io/apps/dco/).