### PR TITLE
elems function should always return enumerable collection (#509)

### DIFF
--- a/assets/js/functions.js
+++ b/assets/js/functions.js
@@ -14,14 +14,14 @@ function createEl(element = 'div') {
   return document.createElement(element);
 }
 
-function elem(selector, parent = document){
+function elem(selector, parent = document) {
   let elem = parent.querySelector(selector);
   return elem != false ? elem : false;
 }
 
 function elems(selector, parent = document) {
   let elems = parent.querySelectorAll(selector);
-  return elems.length ? elems : false;
+  return elems;
 }
 
 function pushClass(el, targetClass) {
@@ -32,19 +32,19 @@ function pushClass(el, targetClass) {
 }
 
 function hasClasses(el) {
-  if(isObj(el)) {
+  if (isObj(el)) {
     const classes = el.classList;
     return classes.length
   }
 }
 
-(function markInlineCodeTags(){
+(function markInlineCodeTags() {
   const codeBlocks = elems('code');
-  if(codeBlocks) {
-    codeBlocks.forEach(function(codeBlock){
-          // Fix for orgmode inline code, leave 'verbatim' alone as well
-          containsClass(codeBlock, 'verbatim') ? pushClass(codeBlock, 'noClass') :false;
-      hasClasses(codeBlock) ? false: pushClass(codeBlock, 'noClass');
+  if (codeBlocks) {
+    codeBlocks.forEach(function (codeBlock) {
+      // Fix for orgmode inline code, leave 'verbatim' alone as well
+      containsClass(codeBlock, 'verbatim') ? pushClass(codeBlock, 'noClass') : false;
+      hasClasses(codeBlock) ? false : pushClass(codeBlock, 'noClass');
     });
   }
 })();
@@ -64,7 +64,7 @@ function modifyClass(el, targetClass) {
 }
 
 function containsClass(el, targetClass) {
-  if (isObj(el) && targetClass && el !== document ) {
+  if (isObj(el) && targetClass && el !== document) {
     return el.classList.contains(targetClass) ? true : false;
   }
 }
@@ -100,9 +100,9 @@ function isBlank(str) {
 }
 
 function isMatch(element, selectors) {
-  if(isObj(element)) {
-    if(selectors.isArray) {
-      let matching = selectors.map(function(selector){
+  if (isObj(element)) {
+    if (selectors.isArray) {
+      let matching = selectors.map(function (selector) {
         return element.matches(selector)
       })
       return matching.includes(true);
@@ -188,7 +188,7 @@ function forEach(node, callback) {
 
 function findQuery(query = 'query') {
   const urlParams = new URLSearchParams(window.location.search);
-  if(urlParams.has(query)){
+  if (urlParams.has(query)) {
     let c = urlParams.get(query);
     return c;
   }
@@ -205,15 +205,15 @@ function wrapText(text, context, wrapper = 'mark') {
     let pattern = new RegExp(text, "gi");
     let matches = text.length ? c.match(pattern) : null;
 
-    if(matches) {
-      matches.forEach(function(matchStr){
+    if (matches) {
+      matches.forEach(function (matchStr) {
         c = c.replaceAll(matchStr, `${open}${matchStr}${close}`);
         context.innerHTML = c;
       });
 
       const images = elems('img', context);
 
-      if(images) {
+      if (images) {
         images.forEach(image => {
           image.src = image.src.replaceAll(open, '').replaceAll(close, '').replaceAll(escapedOpen, '').replaceAll(escapedClose, '');
         });
@@ -223,12 +223,12 @@ function wrapText(text, context, wrapper = 'mark') {
 
   const contents = ["h1", "h2", "h3", "h4", "h5", "h6", "p", "code", "td"];
 
-  contents.forEach(function(c){
+  contents.forEach(function (c) {
     const cs = elems(c, context);
-    if(cs.length) {
-      cs.forEach(function(cx, index){
-        if(cx.children.length >= 1) {
-          Array.from(cx.children).forEach(function(child){
+    if (cs.length) {
+      cs.forEach(function (cx, index) {
+        if (cx.children.length >= 1) {
+          Array.from(cx.children).forEach(function (child) {
             wrap(child);
           })
           wrap(cx);
@@ -241,25 +241,25 @@ function wrapText(text, context, wrapper = 'mark') {
   });
 
   const hyperLinks = elems('a');
-  if(hyperLinks) {
-    hyperLinks.forEach(function(link){
+  if (hyperLinks) {
+    hyperLinks.forEach(function (link) {
       link.href = link.href.replaceAll(encodeURI(open), "").replaceAll(encodeURI(close), "");
     });
   }
 }
 
 function emptyEl(el) {
-  while(el.firstChild)
-  el.removeChild(el.firstChild);
+  while (el.firstChild)
+    el.removeChild(el.firstChild);
 }
 
 function matchTarget(element, selector) {
-  if(isObj(element)) {
+  if (isObj(element)) {
     let matches = false;
     const isExactMatch = element.matches(selector);
     const exactTarget = element.closest(selector);
     matches = isExactMatch ? isExactMatch : exactTarget;
-    return  {
+    return {
       exact: isExactMatch, // is exact target
       valid: matches,
       actual: exactTarget
@@ -270,15 +270,15 @@ function matchTarget(element, selector) {
 function goBack(target) {
   const matchCriteria = matchTarget(target, `.${goBackClass}`);
 
-  if(matchCriteria.valid) {
+  if (matchCriteria.valid) {
     history.back();
   }
 }
 
-(function() {
+(function () {
   const bodyElement = elem('body');
   const platform = navigator.platform.toLowerCase();
-  if(platform.includes("win")) {
+  if (platform.includes("win")) {
     pushClass(bodyElement, 'windows');
   }
 })();

--- a/assets/js/functions.js
+++ b/assets/js/functions.js
@@ -14,7 +14,7 @@ function createEl(element = 'div') {
   return document.createElement(element);
 }
 
-function elem(selector, parent = document) {
+function elem(selector, parent = document){
   let elem = parent.querySelector(selector);
   return elem != false ? elem : false;
 }
@@ -32,19 +32,19 @@ function pushClass(el, targetClass) {
 }
 
 function hasClasses(el) {
-  if (isObj(el)) {
+  if(isObj(el)) {
     const classes = el.classList;
     return classes.length
   }
 }
 
-(function markInlineCodeTags() {
+(function markInlineCodeTags(){
   const codeBlocks = elems('code');
-  if (codeBlocks) {
-    codeBlocks.forEach(function (codeBlock) {
-      // Fix for orgmode inline code, leave 'verbatim' alone as well
-      containsClass(codeBlock, 'verbatim') ? pushClass(codeBlock, 'noClass') : false;
-      hasClasses(codeBlock) ? false : pushClass(codeBlock, 'noClass');
+  if(codeBlocks) {
+    codeBlocks.forEach(function(codeBlock){
+          // Fix for orgmode inline code, leave 'verbatim' alone as well
+          containsClass(codeBlock, 'verbatim') ? pushClass(codeBlock, 'noClass') :false;
+      hasClasses(codeBlock) ? false: pushClass(codeBlock, 'noClass');
     });
   }
 })();
@@ -64,7 +64,7 @@ function modifyClass(el, targetClass) {
 }
 
 function containsClass(el, targetClass) {
-  if (isObj(el) && targetClass && el !== document) {
+  if (isObj(el) && targetClass && el !== document ) {
     return el.classList.contains(targetClass) ? true : false;
   }
 }
@@ -100,9 +100,9 @@ function isBlank(str) {
 }
 
 function isMatch(element, selectors) {
-  if (isObj(element)) {
-    if (selectors.isArray) {
-      let matching = selectors.map(function (selector) {
+  if(isObj(element)) {
+    if(selectors.isArray) {
+      let matching = selectors.map(function(selector){
         return element.matches(selector)
       })
       return matching.includes(true);
@@ -188,7 +188,7 @@ function forEach(node, callback) {
 
 function findQuery(query = 'query') {
   const urlParams = new URLSearchParams(window.location.search);
-  if (urlParams.has(query)) {
+  if(urlParams.has(query)){
     let c = urlParams.get(query);
     return c;
   }
@@ -205,15 +205,15 @@ function wrapText(text, context, wrapper = 'mark') {
     let pattern = new RegExp(text, "gi");
     let matches = text.length ? c.match(pattern) : null;
 
-    if (matches) {
-      matches.forEach(function (matchStr) {
+    if(matches) {
+      matches.forEach(function(matchStr){
         c = c.replaceAll(matchStr, `${open}${matchStr}${close}`);
         context.innerHTML = c;
       });
 
       const images = elems('img', context);
 
-      if (images) {
+      if(images) {
         images.forEach(image => {
           image.src = image.src.replaceAll(open, '').replaceAll(close, '').replaceAll(escapedOpen, '').replaceAll(escapedClose, '');
         });
@@ -223,12 +223,12 @@ function wrapText(text, context, wrapper = 'mark') {
 
   const contents = ["h1", "h2", "h3", "h4", "h5", "h6", "p", "code", "td"];
 
-  contents.forEach(function (c) {
+  contents.forEach(function(c){
     const cs = elems(c, context);
-    if (cs.length) {
-      cs.forEach(function (cx, index) {
-        if (cx.children.length >= 1) {
-          Array.from(cx.children).forEach(function (child) {
+    if(cs.length) {
+      cs.forEach(function(cx, index){
+        if(cx.children.length >= 1) {
+          Array.from(cx.children).forEach(function(child){
             wrap(child);
           })
           wrap(cx);
@@ -241,25 +241,25 @@ function wrapText(text, context, wrapper = 'mark') {
   });
 
   const hyperLinks = elems('a');
-  if (hyperLinks) {
-    hyperLinks.forEach(function (link) {
+  if(hyperLinks) {
+    hyperLinks.forEach(function(link){
       link.href = link.href.replaceAll(encodeURI(open), "").replaceAll(encodeURI(close), "");
     });
   }
 }
 
 function emptyEl(el) {
-  while (el.firstChild)
-    el.removeChild(el.firstChild);
+  while(el.firstChild)
+  el.removeChild(el.firstChild);
 }
 
 function matchTarget(element, selector) {
-  if (isObj(element)) {
+  if(isObj(element)) {
     let matches = false;
     const isExactMatch = element.matches(selector);
     const exactTarget = element.closest(selector);
     matches = isExactMatch ? isExactMatch : exactTarget;
-    return {
+    return  {
       exact: isExactMatch, // is exact target
       valid: matches,
       actual: exactTarget
@@ -270,15 +270,15 @@ function matchTarget(element, selector) {
 function goBack(target) {
   const matchCriteria = matchTarget(target, `.${goBackClass}`);
 
-  if (matchCriteria.valid) {
+  if(matchCriteria.valid) {
     history.back();
   }
 }
 
-(function () {
+(function() {
   const bodyElement = elem('body');
   const platform = navigator.platform.toLowerCase();
-  if (platform.includes("win")) {
+  if(platform.includes("win")) {
     pushClass(bodyElement, 'windows');
   }
 })();


### PR DESCRIPTION

<!--- Please provide a general summary of your changes in the title above. If GitHub has inserted "Signed-off-by" you can remove it if you like. -->

## Pull Request type

<!-- To ensure we're able to review your PR quickly, limit your pull request to one type of change. Submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bug-fix
- [ ] Feature (functionality, design, translations, etc.)
- [ ] Documentation change
- [ ] Project management (tests, CI, GitHub configuration, etc.)
- [ ] Other (please describe):

## Current state

<!-- Please describe the current behavior, content, or docs that you are modifying -- or link to relevant issue(s). -->

Issue Number(s): https://github.com/chipzoller/hugo-clarity/issues/509

## Proposed changes

elems function should return enumerable collection because some its clients don't check what a type is returned from the function and use forEach().

## Screenshots, if applicable

<!-- For visual changes to the theme, this is required. -->

## Checklist

<!-- Ensure you've completed the following items, as appropriate, before submitting your PR. -->

- [x] **Bug-fixes and new features:** I have tested locally with the [latest release of Hugo extended](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance).
- [x] **Bug-fixes, new features, and doc changes:** I have updated the relevant documentation as part of this PR.
- [x] **All PRs:** I have [signed off](https://github.com/chipzoller/hugo-clarity/blob/master/CONTRIBUTING.md#how-to-submit-a-pull-request) (using `git commit -s ...`), or if not possible due to developer environment constraints, will comment below confirming that I am adhering to the [Developer Certificate of Origin](https://probot.github.io/apps/dco/).
