### PR TITLE
fix umami analytics parameters location

### DIFF
--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -20,6 +20,10 @@ google_tag_manager_id = ""
 # Baidu analytics Id
 # baidu_analytics = "XXXXXXXX"
 
+# Umami Analytics -- https://umami.is/
+# umami_data_website_id = "GUID-8-4-4-4-12" # Umami Analytics data website id - GUID format (8-4-4-4-12)
+# umami_script_url = "https://cloud.umami.is/script.js" # Umami Analytics script URL
+
 # limit the number of taxonomies links shown on the sidebar of each page by default.
 numberOfTagsShown = 14 # Applies for all other default & custom taxonomies. e.g categories, brands see https://gohugo.io/content-management/taxonomies#what-is-a-taxonomy
 
@@ -167,10 +171,6 @@ enable = false                      # To enable matomo analytics change to `true
 websiteDomain = "example.com"       # Set the domain name of your website, in most cases same as your base URL this is required.
 matomoDomain = "matomo.example.com" # Set to Matomo domain
 matomoSiteID = "1"                  # Default is set to 1, change this to the siteid being tracked
-
-# Umami Analytics -- https://umami.is/
-# umami_data_website_id = "GUID-8-4-4-4-12" # Umami Analytics data website id - GUID format (8-4-4-4-12)
-# umami_script_url = "https://cloud.umami.is/script.js" # Umami Analytics script URL
 
 [cdn] # a CDN shortcode to generate links for your images and files in buckets such as B2, S3, etc.  
 url = "https://some.url.scheme/"  # your base CDN url such as "https://images.site.com/" (including the trailing slash)


### PR DESCRIPTION

<!--- Please provide a general summary of your changes in the title above. If GitHub has inserted "Signed-off-by" you can remove it if you like. -->

## Pull Request type

<!-- To ensure we're able to review your PR quickly, limit your pull request to one type of change. Submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bug-fix
- [ ] Feature (functionality, design, translations, etc.)
- [ ] Documentation change
- [ ] Project management (tests, CI, GitHub configuration, etc.)
- [ ] Other (please describe):

## Current state

When defining variables 'umami_data_website_id' and 'umami_script_url' in params.toml the umami analytics is not added to the website and the tracking script is not loaded when browsing the website (in production, not development).

Issue Number(s): 511

## Proposed changes

Moving the umami lines in params.toml higher up, for example after line 22 fixes this issue.

## Screenshots, if applicable

<!-- For visual changes to the theme, this is required. -->

## Checklist

<!-- Ensure you've completed the following items, as appropriate, before submitting your PR. -->

- [x] **Bug-fixes and new features:** I have tested locally with the [latest release of Hugo extended](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance).
- [x] **Bug-fixes, new features, and doc changes:** I have updated the relevant documentation as part of this PR.
- [x] **All PRs:** I have [signed off](https://github.com/chipzoller/hugo-clarity/blob/master/CONTRIBUTING.md#how-to-submit-a-pull-request) (using `git commit -s ...`), or if not possible due to developer environment constraints, will comment below confirming that I am adhering to the [Developer Certificate of Origin](https://probot.github.io/apps/dco/).
