### PR TITLE
fix: use .Page.Resources.GetMatch in image partial for page bundles

### DIFF
--- a/layouts/partials/image.html
+++ b/layouts/partials/image.html
@@ -46,7 +46,15 @@
   {{- $scratch.Add "classes" " image_internal" -}}
   {{ $file = (path.Clean $file) }}
   {{- if eq $bundle true -}}
-    {{ $image = .Resources.GetMatch $file }}
+    {{ $image = .Page.Resources.GetMatch $file }}
+    {{- if $image -}}
+      {{- if eq $image.MediaType.SubType "svg" -}}
+        {{- $image = "" -}}
+        {{- $scratch.Add "classes" " image_svg" -}}
+      {{- end -}}
+    {{- else -}}
+      {{- $bundle = false -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Than Chip for your great theme. Three related fixes in the local image branch of `image.html`:

1. Replace `.Resources.GetMatch` with `.Page.Resources.GetMatch` — when `image.html` is called via `excerpt.html` with a dict context, `.` is the dict, not the page. `.Resources` is nil on a dict, causing a nil pointer when `usePageBundles` is true.

2. Handle local SVG resources in page bundles — SVG resources don't support `.Width`/`.Height` in Hugo, causing a build error in `figure.html`. Mirror the existing SVG guard that already exists for remote (http) images.

3. Fall back to non-bundle mode when resource is not found — when `.Page.Resources.GetMatch` returns nil (e.g. for images served from `static/` such as the site logo), pass `bundle=false` to `figure.html` so it does not prepend the page web path, avoiding a broken URL.

## Pull Request type

- [x] Bug-fix

## Current state

When a site uses page bundles (either globally via `usePageBundles = true` or per-page via `usePageBundles: true` in front matter), three bugs occur in `image.html`:

1. `excerpt.html` calls `image.html` with `(dict "file" . "alt" $.Title "type" "thumbnail" "Page" $.Page)`. Inside the partial, `.` is that dict — `.Resources` is nil on a dict, so `.Resources.GetMatch` always fails silently and returns no image resource.

2. Local SVG files in a page bundle cause a build panic because `figure.html` tries to call `.Width` and `.Height` on the resource. The existing guard for SVGs only covers remote (HTTP) images.

3. When a file is referenced but does not exist as a page resource (e.g. a logo served from `static/`), `GetMatch` returns nil but `bundle` stays `true`. `figure.html` then prepends the page's `webPath`, producing a doubled URL (`/2024/01/my-post/wp-content/uploads/logo.png`) — a 404.

## Proposed changes

A single targeted change to the local image branch in `layouts/partials/image.html`:

```diff
-    {{ $image = .Resources.GetMatch $file }}
+    {{ $image = .Page.Resources.GetMatch $file }}
+    {{- if $image -}}
+      {{- if eq $image.MediaType.SubType "svg" -}}
+        {{- $image = "" -}}
+        {{- $scratch.Add "classes" " image_svg" -}}
+      {{- end -}}
+    {{- else -}}
+      {{- $bundle = false -}}
+    {{- end -}}
```
Apply to this commit: [layouts/partials/image.html](https://github.com/arey/javaetmoi/commit/869d499c7b21aa5c280c573ebd5112e3e7516d59#diff-6df0b4e56673418819f3d04c957716668d3fc541d64d10bb50b3ad8c30381599)