### PR TITLE
updates for hugo 1.56:

### DIFF
--- a/layouts/partials/follow.html
+++ b/layouts/partials/follow.html
@@ -1,5 +1,5 @@
 {{- $base := absURL "" }}
-{{- $items := .Site.Data.social }}
+{{- $items := hugo.Data.social }}
 {{- $social := .Site.Menus.social }}
 {{- with $social }}
   {{- $items = . }}

--- a/layouts/partials/func/getDefaultLanguage.html
+++ b/layouts/partials/func/getDefaultLanguage.html
@@ -1,12 +1,1 @@
-{{ $defaultLanguage := site.LanguageCode }}
-{{ if hugo.IsMultilingual }}
-  {{ $languages := site.Languages }}
-  {{ $order := slice }}
-  {{ range $languages }}
-    {{ $order = append .Weight $order }}
-  {{ end }}
-  <!-- Assumes the default language will have the lowest weight -->
-  {{ $defaultLanguageIndex := index (sort $order) 0 }}
-  {{ $defaultLanguage = index (where $languages "Weight" $defaultLanguageIndex) 0 }}
-{{ end }}
-{{ return $defaultLanguage }}
+{{ return site.Params.defaultContentLanguage }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -10,7 +10,7 @@
     {{- end }}
     <div class='nav_body nav_body_{{ default "left" $params.mobileNavigation }}'>
       {{ $context := . }}
-      {{ $menuData := .Site.Data.menu }}
+      {{ $menuData := hugo.Data.menu }}
       {{ with $menuData }}
         {{ partial "nav" (dict "context" $context "menu" $menuData) }}
       {{- else }}

--- a/layouts/partials/image.html
+++ b/layouts/partials/image.html
@@ -46,7 +46,15 @@
   {{- $scratch.Add "classes" " image_internal" -}}
   {{ $file = (path.Clean $file) }}
   {{- if eq $bundle true -}}
-    {{ $image = .Resources.GetMatch $file }}
+    {{ $image = .Page.Resources.GetMatch $file }}
+    {{- if $image -}}
+      {{- if eq $image.MediaType.SubType "svg" -}}
+        {{- $image = "" -}}
+        {{- $scratch.Add "classes" " image_svg" -}}
+      {{- end -}}
+    {{- else -}}
+      {{- $bundle = false -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,6 +1,6 @@
 {{- $menu := .menu }}
 {{- $iconsDir := default "icons/" site.Params.iconsDir }}
-{{ $menuData := site.Data.menu }}
+{{ $menuData := hugo.Data.menu }}
 {{- $link := .context.Permalink }}
 {{- $url := "" }}
 {{- $name := "" }}


### PR DESCRIPTION
Hugo is currently reporting deprecations, during the build. This PR creates adjustments, so the build will also work after Hugo 1.68

<!--- Please provide a general summary of your changes in the title above. If GitHub has inserted "Signed-off-by" you can remove it if you like. -->

## Pull Request type

<!-- To ensure we're able to review your PR quickly, limit your pull request to one type of change. Submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bug-fix
- [ ] Feature (functionality, design, translations, etc.)
- [ ] Documentation change
- [ ] Project management (tests, CI, GitHub configuration, etc.)
- [X ] Other (please describe):

## Current state

WARN  deprecated: .Site.Data was deprecated in Hugo v0.156.0 and will be removed in a future release. Use hugo.Data instead.
WARN  deprecated: .Site.Languages was deprecated in Hugo v0.156.0 and will be removed in a future release. See https://discourse.gohugo.io/t/56732.


Issue Number(s): 

## Proposed changes

<!-- Please describe the changes this PR makes. -->

## Screenshots, if applicable

<!-- For visual changes to the theme, this is required. -->

## Checklist

<!-- Ensure you've completed the following items, as appropriate, before submitting your PR. -->

- [ ] **Bug-fixes and new features:** I have tested locally with the [latest release of Hugo extended](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance).
- [ ] **Bug-fixes, new features, and doc changes:** I have updated the relevant documentation as part of this PR.
- [ ] **All PRs:** I have [signed off](https://github.com/chipzoller/hugo-clarity/blob/master/CONTRIBUTING.md#how-to-submit-a-pull-request) (using `git commit -s ...`), or if not possible due to developer environment constraints, will comment below confirming that I am adhering to the [Developer Certificate of Origin](https://probot.github.io/apps/dco/).
