### PR TITLE
fix: Update fields which are deprecated in v0.158

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .DS_Store
 public
+
+# IDEs
+.vscode/
+.idea/

--- a/exampleSite/config/_default/languages.toml
+++ b/exampleSite/config/_default/languages.toml
@@ -1,11 +1,11 @@
 [en]
   title = "Clarity"
-  LanguageName = "English"
+  label = "English"
   weight = 1
 
 [pt]
   title = "Claridade" # just for the sake of showing this is possible
-  LanguageName = "Português"
+  label = "Português"
   weight = 2
 
   # tip: assign the default language the lowest Weight

--- a/exampleSite/config/_default/languages.toml
+++ b/exampleSite/config/_default/languages.toml
@@ -1,11 +1,13 @@
 [en]
   title = "Clarity"
-  label = "English"
+  label = "English" # label was added in Hugo v0.158.0
+  LanguageName = "English" # LanguageName was deprecated in Hugo v0.158.0
   weight = 1
 
 [pt]
   title = "Claridade" # just for the sake of showing this is possible
-  label = "Português"
+  label = "Português" # label was added in Hugo v0.158.0
+  LanguageName = "Português" # LanguageName was deprecated in Hugo v0.158.0
   weight = 2
 
   # tip: assign the default language the lowest Weight

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -16,7 +16,7 @@
     <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
     <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
-    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
+    <generator>Hugo -- gohugo.io</generator>{{ with .Site.Language.Locale }}
     <language>{{.}}</language>{{end}}{{ with .Site.Params.Author.email }}
     <managingEditor>{{.}}{{ with $.Site.Params.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Params.Author.email }}
     <webMaster>{{.}}{{ with $.Site.Params.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -16,8 +16,13 @@
     <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
     <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
-    <generator>Hugo -- gohugo.io</generator>{{ with .Site.Language.Locale }}
-    <language>{{.}}</language>{{end}}{{ with .Site.Params.Author.email }}
+    <generator>Hugo -- gohugo.io</generator>
+    {{- if lt hugo.Version "0.158.0" -}}
+    {{ with .Site.LanguageCode }}<language>{{.}}</language>{{end}}
+    {{- else -}}
+    {{ with .Site.Language.Locale }}<language>{{.}}</language>{{end}}
+    {{- end -}}
+    {{ with .Site.Params.Author.email }}
     <managingEditor>{{.}}{{ with $.Site.Params.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Params.Author.email }}
     <webMaster>{{.}}{{ with $.Site.Params.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
     <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -22,7 +22,7 @@
         <div class="nav_sub">
           <span class="nav_child"></span>
           {{ range .Site.Home.AllTranslations }}
-          <a href="{{ .Permalink }}" class="nav_child nav_item">{{ .Language.LanguageName }}</a>
+          <a href="{{ .Permalink }}" class="nav_child nav_item">{{ .Language.Label }}</a>
           {{ end }}
         </div>
       </div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -22,7 +22,13 @@
         <div class="nav_sub">
           <span class="nav_child"></span>
           {{ range .Site.Home.AllTranslations }}
-          <a href="{{ .Permalink }}" class="nav_child nav_item">{{ .Language.Label }}</a>
+          <a href="{{ .Permalink }}" class="nav_child nav_item">
+            {{- if lt hugo.Version "0.158.0" -}}
+            {{ .Language.LanguageName }}
+            {{- else -}}
+            {{ .Language.Label }}
+            {{- end -}}
+          </a>
           {{ end }}
         </div>
       </div>

--- a/layouts/partials/i18nlist.html
+++ b/layouts/partials/i18nlist.html
@@ -4,7 +4,7 @@
   <h3 class="mb-0">{{ T "translations" }}:</h3>
   <nav class="tags_nav">
     {{ range $index, $_ := . }}
-      <a href="{{ .Permalink }}" class="post_tag button button_translucent">{{ replace (printf "%#v" .Language.LanguageName) "\"" "" }}</a> 
+      <a href="{{ .Permalink }}" class="post_tag button button_translucent">{{ replace (printf "%#v" .Language.Label) "\"" "" }}</a>
       <!-- {{ if lt $index (sub $translationsSize 1)}} |{{ end }} -->
     {{ end }}
     </nav>

--- a/layouts/partials/i18nlist.html
+++ b/layouts/partials/i18nlist.html
@@ -4,7 +4,13 @@
   <h3 class="mb-0">{{ T "translations" }}:</h3>
   <nav class="tags_nav">
     {{ range $index, $_ := . }}
-      <a href="{{ .Permalink }}" class="post_tag button button_translucent">{{ replace (printf "%#v" .Language.Label) "\"" "" }}</a>
+      {{- $label := "" -}}
+      {{- if lt hugo.Version "0.158.0" -}}
+      {{- $label = .Language.LanguageName -}}
+      {{- else -}}
+      {{- $label = .Language.Label -}}
+      {{- end -}}
+      <a href="{{ .Permalink }}" class="post_tag button button_translucent">{{ replace (printf "%#v" $label) "\"" "" }}</a>
       <!-- {{ if lt $index (sub $translationsSize 1)}} |{{ end }} -->
     {{ end }}
     </nav>


### PR DESCRIPTION
v0.158 (March 2026) deprecated a list of language related fields, these will be removed in around 12 months and will cause build failures. This commit modifies the instances of the deprecated fields to now be correct.

See [0.158 release notes](https://github.com/gohugoio/hugo/releases/tag/v0.158.0) for details of the fields that have been removed, and what has replaced them and [this article](https://discourse.gohugo.io/t/deprecations-in-v0-158-0/56869) for the rationale of the change.

<!--- Please provide a general summary of your changes in the title above. If GitHub has inserted "Signed-off-by" you can remove it if you like. -->

## Pull Request type

<!-- To ensure we're able to review your PR quickly, limit your pull request to one type of change. Submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bug-fix
- [ ] Feature (functionality, design, translations, etc.)
- [ ] Documentation change
- [ ] Project management (tests, CI, GitHub configuration, etc.)
- [ ] Other (please describe):

## Current state

`LanguageName` and `LanguageCode` are used by this project but have been deprecated in [v0.158.0](https://github.com/gohugoio/hugo/releases/tag/v0.158.0). Building a site using this theme will present the following `WARNING`:
```
WARN  deprecated: project config key languages.pt.languageName was deprecated in Hugo v0.158.0 and will be removed in a future release. Use languages.pt.label instead.
WARN  deprecated: project config key languages.en.languageName was deprecated in Hugo v0.158.0 and will be removed in a future release. Use languages.en.label instead.
WARN  deprecated: .Language.LanguageName was deprecated in Hugo v0.158.0 and will be removed in a future release. Use .Language.Label instead.
WARN  deprecated: .Site.LanguageCode was deprecated in Hugo v0.158.0 and will be removed in a future release. Use .Site.Language.Locale instead.
```

This PR updates the use of the deprecated language fields.

Issue Number(s): 

## Proposed changes

<!-- Please describe the changes this PR makes. -->

## Screenshots, if applicable

<!-- For visual changes to the theme, this is required. -->

## Checklist

<!-- Ensure you've completed the following items, as appropriate, before submitting your PR. -->

- [X] **Bug-fixes and new features:** I have tested locally with the [latest release of Hugo extended](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance).
- [ ] **Bug-fixes, new features, and doc changes:** I have updated the relevant documentation as part of this PR.
- [X] **All PRs:** I have [signed off](https://github.com/chipzoller/hugo-clarity/blob/master/CONTRIBUTING.md#how-to-submit-a-pull-request) (using `git commit -s ...`), or if not possible due to developer environment constraints, will comment below confirming that I am adhering to the [Developer Certificate of Origin](https://probot.github.io/apps/dco/).
