### PR TITLE
Update Gitpod browser extension link

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ There are several ways to use this theme:
 
 For trying out the theme, quick experimentation, and to contribute Pull Requests, Gitpod is the easiest option. Use the button above and it will spin up a prebuilt environment with a site ready to go.
 
-If you want to contribute a PR, [this is a good overview of that process](https://jldec.me/using-gitpod-to-create-a-pr), and there's also an [optional browser extension](https://www.gitpod.io/docs/browser-extension). [Read more about contributing to Hugo Clarity](CONTRIBUTING.md)
+If you want to contribute a PR, [this is a good overview of that process](https://jldec.me/using-gitpod-to-create-a-pr), and there's also an [optional browser extension](https://ona.com/docs/classic/user/introduction/getting-started/quickstart/overview#installing-the-gitpod-browser-extension). [Read more about contributing to Hugo Clarity](CONTRIBUTING.md)
 
 ### Option 1b: Development on your machine
 


### PR DESCRIPTION
## Pull Request type

- [ ] Bug-fix
- [ ] Feature (functionality, design, translations, etc.)
- [x] Documentation change
- [ ] Project management (tests, CI, GitHub configuration, etc.)
- [ ] Other (please describe):

## Current state

Issue Number(s): #514

The README's optional Gitpod browser extension link points to a page that now returns HTTP 404.

## Proposed changes

Update the link to the browser extension section in the current official Ona-hosted Gitpod Classic quickstart. No theme behavior or other documentation changes.

## Screenshots, if applicable

Not applicable; this is a link-only documentation change.

## Checklist

- [ ] **Bug-fixes and new features:** I have tested locally with the latest release of Hugo extended. Not applicable to this documentation-only change.
- [x] **Bug-fixes, new features, and doc changes:** I have updated the relevant documentation as part of this PR.
- [x] **All PRs:** I have signed off using `git commit -s` and am adhering to the Developer Certificate of Origin.

## Verification

- old documentation URL returns HTTP 404
- replacement official page returns HTTP 200 and contains the browser extension installation section
- `git diff --check`

Closes #514
